### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,6 +2,8 @@
 # If security settings have been properly configured, any branch that fails this workflow will be blocked from being merged into main and possibly other common branches link develop depending your specific settings
 
 name: PR Checks
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Chris-Wolfgang/DbContextBuilder/security/code-scanning/2](https://github.com/Chris-Wolfgang/DbContextBuilder/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` key at the top of the workflow, at the root level. This ensures all jobs and steps inherit the least privilege permission required, specifically setting `contents: read`. This minimizes the scope of the GITHUB_TOKEN and adheres to the principle of least privilege without altering existing workflow logic. This requires a single edit—adding a `permissions:` block at the root of `.github/workflows/pr.yaml`, just below the `name` key and before the `on:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
