### PR TITLE
Fix package icon path and update file path separators

### DIFF
--- a/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
@@ -15,7 +15,7 @@
 		<AssemblyVersion>1.0.0</AssemblyVersion>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-		<PackageIcon>Content/dbcontext-builder.png</PackageIcon>
+		<PackageIcon>dbcontext-builder.png</PackageIcon>
 		<ApplicationIcon>Content/dbcontext-builder.ico</ApplicationIcon>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<SignAssembly>False</SignAssembly>
@@ -45,7 +45,7 @@
 	<ItemGroup>
 		<!-- Include the icon and README file directly in the package's root -->
 		<None Include="..\..\README.md" Pack="True" PackagePath="/" />
-		<None Include="Content/dbcontext-builder.png" Pack="true" PackagePath="/" />
-		<None Include="Content/dbcontext-builder.ico" Pack="true" PackagePath="/" />
+		<None Include="Content\dbcontext-builder.png" Pack="true" PackagePath="/" />
+		<None Include="Content\dbcontext-builder.ico" Pack="true" PackagePath="/" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Updated the `<PackageIcon>` path in `Wolfgang.DbContextBuilder-Core.csproj` to remove the `Content/` directory. Replaced forward slashes (`/`) with backslashes (`\`) in `<None>` item group paths for `dbcontext-builder.png` and `dbcontext-builder.ico`.

## Description

<!-- Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes/Complete # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

<!-- Please add any screenshots or gifs to help reviewers understand your changes. -->

## Additional context

<!-- Add any other context about the pull request here. -->
