### PR TITLE
Update EF version floors and remove unused packages

### DIFF
--- a/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
@@ -56,14 +56,12 @@
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
 
-	  <PackageReference Include="System.Net.Http" Version="4.3.4" />
-	  <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 
 
-	  <!-- Lock EF to version 10.x but not 10 or later -->
-	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[10.0.0,11.0.0)" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[10.0.0,11.0.0)" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[10.0.0,11.0.0)" />
+	  <!-- Lock EF to version 10.x but not 11 or later -->
+	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[10.0.5,11.0.0)" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[10.0.5,11.0.0)" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[10.0.5,11.0.0)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
@@ -53,8 +53,6 @@
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
 
-	  <PackageReference Include="System.Net.Http" Version="4.3.4" />
-	  <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 
 
 	  <!-- Lock EF to version 6.x but not 7 or later -->

--- a/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
@@ -53,8 +53,6 @@
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
 
-	  <PackageReference Include="System.Net.Http" Version="4.3.4" />
-	  <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 
 
 	  <!-- Lock EF to version 7.x but not 8 or later -->

--- a/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
@@ -53,14 +53,12 @@
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
 
-	  <PackageReference Include="System.Net.Http" Version="4.3.4" />
-	  <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 
 
 	  <!-- Lock EF to version 8.x but not 9 or later -->
-	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[8.0.21,9.0.0)" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[8.0.21,9.0.0)" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[8.0.21,9.0.0)" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[8.0.25,9.0.0)" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[8.0.25,9.0.0)" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[8.0.25,9.0.0)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
@@ -56,14 +56,12 @@
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
 
-	  <PackageReference Include="System.Net.Http" Version="4.3.4" />
-	  <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 
 
 	  <!-- Lock EF to version 9.x but not 10 or later -->
-	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[9.0.10,10.0.0)" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[9.0.10,10.0.0)" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[9.0.10,10.0.0)" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[9.0.14,10.0.0)" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[9.0.14,10.0.0)" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[9.0.14,10.0.0)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
@@ -34,11 +34,10 @@
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.20" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.20" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.20" />
-	  <PackageReference Include="System.Net.Http" Version="4.3.4" />
-	  <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+	  <!-- Lock EF to version 6.x but not 7 or later -->
+	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6.0.36,7.0.0)" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[6.0.36,7.0.0)" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[6.0.36,7.0.0)" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
- Bump EF Core minimum versions to latest patches: EF8 8.0.21→8.0.25, EF9 9.0.10→9.0.14, EF10 10.0.0→10.0.5
- Pin Core project to EF6 version range `[6.0.36,7.0.0)` instead of fixed `7.0.20`
- Remove unused `System.Net.Http` (4.3.4) and `System.Text.RegularExpressions` (4.3.1) from all 6 source projects
- Fix EF10 comment typo: "not 11 or later" instead of "not 10 or later"

## Test plan
- [x] Release build succeeds with 0 errors
- [ ] CI passes all test projects across all TFMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)