### PR TITLE
Prevent dependabot from bumping version-pinned packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,27 @@ updates:
       dotnet-dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "Microsoft.EntityFrameworkCore"
+          - "Microsoft.EntityFrameworkCore.*"
+          - "xunit.runner.visualstudio"
+    ignore:
+      # EF Core packages are version-pinned per project to specific major versions
+      # (e.g., [6.0.36,7.0.0) for EF6, [7.0.20,8.0.0) for EF7, etc.)
+      # Dependabot does not understand NuGet version range syntax and will
+      # break these pins by bumping to the latest major version.
+      - dependency-name: "Microsoft.EntityFrameworkCore"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.EntityFrameworkCore.InMemory"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.EntityFrameworkCore.Sqlite"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.EntityFrameworkCore.SqlServer"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.EntityFrameworkCore.Tools"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.EntityFrameworkCore.Design"
+        update-types: ["version-update:semver-major"]
+      # xunit.runner.visualstudio 3.x is incompatible with xunit 2.x
+      - dependency-name: "xunit.runner.visualstudio"
+        versions: [">=3.0.0"]


### PR DESCRIPTION
## Summary
- Adds `ignore` rules to `dependabot.yml` for EF Core packages to block major version bumps (dependabot doesn't understand NuGet range syntax like `[6.0.36,7.0.0)`)
- Blocks `xunit.runner.visualstudio` >= 3.0.0 (incompatible with xunit 2.x)
- Excludes EF Core and xunit.runner.visualstudio from the grouped `dotnet-dependencies` PR so they don't sneak in via `patterns: ["*"]`

## Context
PR #125 bumped several version-pinned packages across major versions, breaking EF version isolation and xunit compatibility. See [comment on #125](https://github.com/Chris-Wolfgang/DbContextBuilder/pull/125#issuecomment-4106590293) for the full breakdown.

## Test plan
- [ ] Merge this PR first, then close #125
- [ ] Verify next dependabot run does not propose EF Core major bumps or xunit.runner.visualstudio 3.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)