### PR TITLE
Update Repo - 002 - Add gitleaks scanning and concurrency to PR workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,28 @@ on:
   pull_request_target:  # Runs from the main branch, not from PR branch
     branches:
       - main
+concurrency:  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}  cancel-in-progress: true
 jobs:
+  # SECRETS SCAN: Detect leaked credentials before merge
+  # ============================================================================
+  secrets-scan:
+    name: "Secrets Scan (gitleaks)"
+    runs-on: ubuntu-latest
+    if: github.repository != 'Chris-Wolfgang/repo-template'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ============================================================================
   # ============================================================================
   # DETECTION: Check if .csproj files exist
   # ============================================================================


### PR DESCRIPTION
## Summary
- Add concurrency groups and gitleaks scanning to PR workflow

## Test plan
- [ ] Verify PR workflow runs gitleaks scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)