### PR TITLE
Fix -Core TFM and remove prunable packages from -Core-EF10

### DIFF
--- a/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
@@ -56,10 +56,6 @@
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
 
-	  <PackageReference Include="System.Net.Http" Version="4.3.4" />
-	  <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-
-
 	  <!-- Lock EF to version 10.x but not 11 or later -->
 	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[10.0.5,11.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[10.0.5,11.0.0)" />

--- a/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<RootNamespace>Wolfgang.DbContextBuilderCore</RootNamespace>
-		<TargetFrameworks>net6.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Version>0.3.3</Version>
 		<Title>Wolfgang.DbContextBuilder for EF</Title>

--- a/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<RootNamespace>Wolfgang.DbContextBuilderCore</RootNamespace>
-		<TargetFrameworks>net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFrameworks>net6.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<Version>0.3.3</Version>
 		<Title>Wolfgang.DbContextBuilder for EF</Title>


### PR DESCRIPTION
## Summary

Fixes the CI build failure on PR #162 caused by NuGet package pruning on .NET 10.

- **DbContextBuilder-Core**: restrict TargetFrameworks to `net6.0` only. The project pins EF Core to `[6.0.36,7.0.0)`, but targeting `net6.0-net10.0` caused the .NET 10 SDK's package pruning to resolve EF 10.0.2 as a framework reference, which is incompatible with net6.0-net9.0. Each EF version already has a dedicated project (`-Core-EF7` through `-Core-EF10`).
- **DbContextBuilder-Core-EF10**: remove `System.Net.Http` and `System.Text.RegularExpressions` — these are framework-provided on net10.0 and trigger NU1510 pruning warnings (treated as errors in Release).

## Pre-existing issue (not addressed)

All `-Core-EF*` projects reference a linked file `DbContextBuilderSqlServerExtensions.cs` that does not exist in the `-Core` project, causing CS2001 errors. This predates this PR.

## Test plan
- [x] `dotnet build` for `-Core` (net6.0) — 0 errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)