### PR TITLE
Add .github/workflows/* to protected file detection

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -91,6 +91,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
           
           # Copy each configuration file from main branch if it exists
@@ -147,11 +149,11 @@ jobs:
             fi
           done
           
-          # Check .globalconfig and .ruleset files using the same git diff approach
+          # Check .globalconfig, .ruleset, and workflow files using the same git diff approach
           # --diff-filter=AMRC: Added, Modified, Renamed, Copied (excludes Deleted)
           while IFS= read -r file; do
             changed_files+=("$file")
-          done < <(git diff --name-only --diff-filter=AMRC main-branch HEAD 2>/dev/null | grep -E '\.(globalconfig|ruleset)$' || true)
+          done < <(git diff --name-only --diff-filter=AMRC main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset)|^\.github/workflows/.*\.ya?ml)$' || true)
           
           if [ ${#changed_files[@]} -gt 0 ]; then
             echo ""
@@ -215,6 +217,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
           
           # Copy each configuration file from main branch if it exists
@@ -258,6 +262,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
 
           # Copy each configuration file from main branch if it exists
@@ -576,8 +582,8 @@ jobs:
             }
           }
           
-          # Handle glob patterns for .globalconfig and .ruleset files
-          $globPatterns = @("*.globalconfig", "*.ruleset")
+          # Handle glob patterns for .globalconfig, .ruleset, and workflow files
+          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
           foreach ($pattern in $globPatterns) {
             $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
             foreach ($file in $files) {
@@ -621,8 +627,8 @@ jobs:
             }
           }
 
-          # Handle glob patterns for .globalconfig and .ruleset files
-          $globPatterns = @("*.globalconfig", "*.ruleset")
+          # Handle glob patterns for .globalconfig, .ruleset, and workflow files
+          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
           foreach ($pattern in $globPatterns) {
             $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
             foreach ($file in $files) {
@@ -847,6 +853,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
           
           # Copy each configuration file from main branch if it exists
@@ -890,6 +898,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
 
           # Copy each configuration file from main branch if it exists
@@ -1200,6 +1210,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
           
           # Copy each configuration file from main branch if it exists
@@ -1243,6 +1255,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
 
           # Copy each configuration file from main branch if it exists


### PR DESCRIPTION
Mirrors [Chris-Wolfgang/repo-template#319](https://github.com/Chris-Wolfgang/repo-template/pull/319) into this repo so workflow files get the same protection as other trusted config files (`.editorconfig`, `Directory.Build.props`, etc.).

## Why
A subtly broken workflow YAML (e.g. duplicate mapping key) can silently disable CI without errors. Try-Pattern hit that exact failure mode this month — a duplicate `run:` key blocked CI for ~2 weeks before being tracked down. Failing fast on workflow modifications gives maintainers a clear 'review carefully' signal.

## What
Adds `.github/workflows/*.yml` and `.github/workflows/*.yaml` to:
- bash `config_files=()` arrays in 'Fetch trusted configuration files' steps
- PowerShell `$globPatterns` in the test-windows fetch step
- the grep regex in the 'Detect protected configuration file changes' step

## Verification
- YAML parses cleanly (`name='PR Checks v3 (Gated)'`, all 6 jobs intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)