### PR TITLE
Bump version 0.4.0 → 0.4.1

### DIFF
--- a/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
@@ -3,7 +3,7 @@
 		<RootNamespace>Wolfgang.DbContextBuilderCore</RootNamespace>
 		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<Version>0.4.0</Version>
+		<Version>0.4.1</Version>
 		<Title>Wolfgang.DbContextBuilder for EF Core 10</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>

--- a/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
@@ -3,7 +3,7 @@
 		<RootNamespace>Wolfgang.DbContextBuilderCore</RootNamespace>
 		<TargetFramework>net6.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<Version>0.4.0</Version>
+		<Version>0.4.1</Version>
 		<Title>Wolfgang.DbContextBuilder for EF Core 6</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>

--- a/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
@@ -3,7 +3,7 @@
 		<RootNamespace>Wolfgang.DbContextBuilderCore</RootNamespace>
 		<TargetFramework>net7.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<Version>0.4.0</Version>
+		<Version>0.4.1</Version>
 		<Title>Wolfgang.DbContextBuilder for EF Core 7</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>

--- a/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
@@ -3,7 +3,7 @@
 		<RootNamespace>Wolfgang.DbContextBuilderCore</RootNamespace>
 		<TargetFramework>net8.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<Version>0.4.0</Version>
+		<Version>0.4.1</Version>
 		<Title>Wolfgang.DbContextBuilder for EF Core 8</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>

--- a/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
@@ -3,7 +3,7 @@
 		<RootNamespace>Wolfgang.DbContextBuilderCore</RootNamespace>
 		<TargetFramework>net9.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<Version>0.4.0</Version>
+		<Version>0.4.1</Version>
 		<Title>Wolfgang.DbContextBuilder for EF Core 9</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>

--- a/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
@@ -3,7 +3,7 @@
 		<RootNamespace>Wolfgang.DbContextBuilderCore</RootNamespace>
 		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<Version>0.4.0</Version>
+		<Version>0.4.1</Version>
 		<Title>Wolfgang.DbContextBuilder for EF</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>


### PR DESCRIPTION
## Summary
The v0.4.0 release failed at the smoke-test step (NU1202: `Wolfgang.DbContextBuilder-Core-EF10` is incompatible with `net8.0`) so nothing was published to NuGet. Immutable releases is enabled, so the v0.4.0 tag cannot be reused.

This bumps to v0.4.1 to re-cut the release on top of the smoke-test fix from #182.

Bumped projects:
- Wolfgang.DbContextBuilder-Core
- Wolfgang.DbContextBuilder-Core-EF6
- Wolfgang.DbContextBuilder-Core-EF7
- Wolfgang.DbContextBuilder-Core-EF8
- Wolfgang.DbContextBuilder-Core-EF9
- Wolfgang.DbContextBuilder-Core-EF10

## Test plan
- [ ] CI passes
- [ ] After merge, create v0.4.1 release; release workflow's smoke-test step now succeeds across all single-TFM packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)