### PR TITLE
Handle .NET Framework TFMs in release smoke test

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -553,10 +553,31 @@ jobs:
               $projectName = "SmokeTest$projectIndex"
               Write-Host "   Creating $projectName targeting $targetFramework" -ForegroundColor DarkGray
 
-              dotnet new console -n $projectName -f $targetFramework
-              if ($LASTEXITCODE -ne 0) {
-                Write-Error "❌ Failed to create test project for $targetFramework"
-                exit $LASTEXITCODE
+              # `dotnet new console` doesn't support .NET Framework TFMs (net4xx).
+              # Scaffold a minimal csproj manually for those; use the template otherwise.
+              if ($targetFramework -match '^net\d{2,3}$') {
+                New-Item -ItemType Directory -Force -Path $projectName | Out-Null
+                $csprojPath = Join-Path $projectName "$projectName.csproj"
+                @(
+                  '<Project Sdk="Microsoft.NET.Sdk">'
+                  '  <PropertyGroup>'
+                  '    <OutputType>Exe</OutputType>'
+                  "    <TargetFramework>$targetFramework</TargetFramework>"
+                  '  </PropertyGroup>'
+                  '</Project>'
+                ) | Set-Content -Path $csprojPath -Encoding UTF8
+
+                $programPath = Join-Path $projectName 'Program.cs'
+                @(
+                  'using System;'
+                  'class Program { static void Main() { Console.WriteLine("Smoke test"); } }'
+                ) | Set-Content -Path $programPath -Encoding UTF8
+              } else {
+                dotnet new console -n $projectName -f $targetFramework
+                if ($LASTEXITCODE -ne 0) {
+                  Write-Error "❌ Failed to create test project for $targetFramework"
+                  exit $LASTEXITCODE
+                }
               }
 
               dotnet add "$projectName/$projectName.csproj" package $packageId --version $packageVersion --source '../nuget-packages'


### PR DESCRIPTION
## Summary
The smoke test fix from #182 used \`dotnet new console -f \$tfm\`, but that template doesn't support .NET Framework TFMs (net462, net47, net471, net472, net48, net481). The v0.5.0 release failed with:

\`\`\`
Error: Invalid option(s):
❌ Failed to create test project for net462
\`\`\`

(The classic \`Wolfgang.DbContextBuilder-EF6\` package targets only .NET Framework TFMs, so it tripped this on the recut release.)

## Fix
For \`net4xx\` TFMs, scaffold a minimal SDK-style csproj + Program.cs manually instead of invoking the template. .NET Core/5+ TFMs continue to use \`dotnet new console\` as before.

## Test plan
- [ ] CI passes
- [ ] After merge, the release smoke test handles both EF Core (.NET 6+) and classic EF6 (.NET Framework) packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)