### PR TITLE
Tolerate immutable-release attach error, fail loudly on others

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -745,16 +745,34 @@ jobs:
         run: zip -r release-coverage.zip ./release-coverage
 
       - name: Attach artifacts to release
-        # Immutable releases lock the asset list at publish time, so this step
-        # cannot succeed when that setting is enabled. Treat as best-effort:
-        # the .nupkg files are already on NuGet.org and stored as workflow
-        # artifacts on this run.
-        continue-on-error: true
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
-        with:
-          tag_name: ${{ github.event.release.tag_name }}
-          files: |
-            ./nuget-packages/*.nupkg
-            ./nuget-packages/*.bom.json
-            release-coverage.zip
+        # Tolerate the "immutable release" case (assets are locked at publish
+        # time so post-publish uploads are rejected) — but fail loudly for any
+        # other error. The .nupkg/.bom.json/coverage files are already on
+        # NuGet.org and stored as workflow artifacts on this run, so the
+        # release-page attachment is a convenience, not the canonical channel.
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -uo pipefail
+          shopt -s nullglob
+          files=(./nuget-packages/*.nupkg ./nuget-packages/*.bom.json release-coverage.zip)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No artifacts found to attach."
+            exit 0
+          fi
+
+          if err=$(gh release upload "$TAG" "${files[@]}" --clobber 2>&1); then
+            echo "$err"
+            exit 0
+          fi
+
+          echo "$err"
+          if echo "$err" | grep -qiE "immutable release|cannot upload asset"; then
+            echo "::warning::Skipping asset attachment — release is immutable. Packages are still on NuGet.org and stored as workflow artifacts on this run."
+            exit 0
+          fi
+          exit 1
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -745,6 +745,11 @@ jobs:
         run: zip -r release-coverage.zip ./release-coverage
 
       - name: Attach artifacts to release
+        # Immutable releases lock the asset list at publish time, so this step
+        # cannot succeed when that setting is enabled. Treat as best-effort:
+        # the .nupkg files are already on NuGet.org and stored as workflow
+        # artifacts on this run.
+        continue-on-error: true
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           tag_name: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Summary
With \"Immutable releases\" enabled on the repo, GitHub locks a release's asset list at publish time. The current release workflow runs after publish, so the asset-attach step fails:

\`\`\`
Cannot upload asset Wolfgang.DbContextBuilder-EF6.0.6.0.nupkg to an immutable release.
GitHub only allows asset uploads before a release is published, so upload assets to a draft release before you publish it.
\`\`\`

This is what happened on v0.6.0 (run 25297603034) — Validate, Pack, NuGet publish, and Docs all succeeded; only the post-publish attach step failed.

## Fix
Replace \`softprops/action-gh-release\` with a small \`gh release upload\` step that:
- **Succeeds normally** when the upload works
- **Logs a warning and exits 0** only when the error message matches the known \`immutable release / cannot upload asset\` pattern
- **Fails loudly** for any other error (network failure, malformed args, etc.)

Avoids the alternative of \`continue-on-error: true\`, which would silently swallow every kind of failure.

The .nupkg / .bom.json / coverage files are already:
- Published to **NuGet.org** (canonical distribution)
- Stored as **workflow artifacts** on the run

So attaching them to the GitHub Release page is a convenience, not the canonical channel.

## Test plan
- [ ] CI passes
- [ ] Next release with immutable releases enabled: attach step logs a warning and overall job reports success
- [ ] If a future error mode appears, it's reported instead of silently swallowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)