### PR TITLE
ci: trigger release.yaml on tag push (fixes immutable-release upload failure)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,10 @@
-name: Release on Published Release
+name: Release on Tag Push
 
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: read  # Default to read-only; individual jobs declare write where required
@@ -26,7 +27,7 @@ jobs:
       - name: Validate release tag matches csproj version
         shell: pwsh
         env:
-          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          RELEASE_TAG_NAME: ${{ github.ref_name }}
         run: |
           # Strip leading 'v' or 'v.' from the tag (v0.3.0 -> 0.3.0, v.0.1.0 -> 0.1.0)
           $tagName = $env:RELEASE_TAG_NAME
@@ -718,7 +719,7 @@ jobs:
       contents: write  # Required by docfx.yaml to push to gh-pages branch
     uses: ./.github/workflows/docfx.yaml
     with:
-      version: ${{ github.event.release.tag_name }}
+      version: ${{ github.ref_name }}
 
   # Attach NuGet packages and coverage report to the GitHub Release page
   update-release-artifacts:
@@ -744,10 +745,16 @@ jobs:
       - name: Zip coverage report
         run: zip -r release-coverage.zip ./release-coverage
 
-      - name: Attach artifacts to release
+      - name: Create release with artifacts
+        # On tag push, this creates a brand-new GitHub Release with assets
+        # attached at creation time. Avoids the "immutable release" rejection
+        # that happens when uploading to an already-published release.
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
-          tag_name: ${{ github.event.release.tag_name }}
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          make_latest: 'true'
           files: |
             ./nuget-packages/*.nupkg
             ./nuget-packages/*.bom.json


### PR DESCRIPTION
## Summary
Switches `release.yaml` from `release.published` trigger to `push: tags: ['v*']` so the workflow creates the GitHub Release itself with assets attached at creation time, rather than trying to upload assets to an already-published release.

## Why
Recent v0.4.0 / v0.5.0 / v0.6.0 release attempts all failed with:

\`\`\`
##[error]Cannot upload asset Wolfgang.DbContextBuilder-EF6.0.6.0.nupkg to an immutable release.
GitHub only allows asset uploads before a release is published, so upload assets to a draft release before you publish it.
\`\`\`

### Root cause
The repo's last successful release (v0.3.3, Dec 2025) was created by the OLD push-on-tag workflow with \`immutable: true\`. When the workflow was changed to \`release.published\`, the user started creating releases manually in the GitHub UI — apparently with the \"Make this release immutable\" toggle on (consistent with v0.3.3's behavior). The workflow's final step (\`softprops/action-gh-release\` uploading \`.nupkg\`s) then tries to attach assets to a release that's *already* both published and immutable, which GitHub now rejects.

### Why other Wolfgang.* repos work
Sampled a handful of recently successful releases — all are \`immutable: false\`. Only DbContextBuilder has releases marked immutable. So this isn't a fleet-wide workflow problem; it's specific to how this repo's releases get created.

## Fix
By triggering on tag push instead, the workflow creates the release itself with all assets present at creation time. There's no \"publish first, upload later\" race.

| Change | Lines |
|---|---|
| \`on: release.published\` → \`on: push.tags: ['v*']\` | 4–7 |
| \`github.event.release.tag_name\` → \`github.ref_name\` (3 places) | 30, 722, 753 |
| Renamed step \"Attach artifacts to release\" → \"Create release with artifacts\" + added \`name\`, \`generate_release_notes: true\`, \`make_latest: 'true'\` | 748–760 |

Releases created by this workflow will be regular non-immutable, matching the rest of the fleet. (\`softprops/action-gh-release@v3\` doesn't expose a \`make_immutable\` input, so we skip immutability rather than introduce a separate API call.)

## Going forward
Releases are made by \`git push origin <tag>\` (or \`git tag <vX.Y.Z> && git push --tags\`). The full validate → pack → smoke → docs → nuget-publish → GitHub-release pipeline runs end-to-end without UI clicks.

## After this lands
- Tag a new version (e.g. v0.6.1 — v0.6.0 git tag exists but its abandoned GitHub Release was deleted) and push to verify the new flow works
- All 18 commits since v0.3.3 (3 version bumps, smoke-test fixes, dependency rolls, template syncs) get released via the new flow

## Note about the protected-files guard
This PR touches \`.github/workflows/release.yaml\` so the \`Detect .NET Projects\` guard will fail it. Maintainer override required to merge — same path as the other workflow-touching PRs.

## Test plan
- [ ] Merge with maintainer override
- [ ] Push a new tag (e.g. v0.6.1) and watch the workflow create the release end-to-end
- [ ] Verify resulting release has assets attached and NuGet packages were published