### PR TITLE
Bump version 0.6.0 → 0.6.1

### DIFF
--- a/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
@@ -3,7 +3,7 @@
 		<RootNamespace>Wolfgang.DbContextBuilderCore</RootNamespace>
 		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<Version>0.6.0</Version>
+		<Version>0.6.1</Version>
 		<Title>Wolfgang.DbContextBuilder for EF Core 10</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>

--- a/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
@@ -3,7 +3,7 @@
 		<RootNamespace>Wolfgang.DbContextBuilderCore</RootNamespace>
 		<TargetFramework>net6.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<Version>0.6.0</Version>
+		<Version>0.6.1</Version>
 		<Title>Wolfgang.DbContextBuilder for EF Core 6</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>

--- a/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
@@ -3,7 +3,7 @@
 		<RootNamespace>Wolfgang.DbContextBuilderCore</RootNamespace>
 		<TargetFramework>net7.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<Version>0.6.0</Version>
+		<Version>0.6.1</Version>
 		<Title>Wolfgang.DbContextBuilder for EF Core 7</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>

--- a/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
@@ -3,7 +3,7 @@
 		<RootNamespace>Wolfgang.DbContextBuilderCore</RootNamespace>
 		<TargetFramework>net8.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<Version>0.6.0</Version>
+		<Version>0.6.1</Version>
 		<Title>Wolfgang.DbContextBuilder for EF Core 8</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>

--- a/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
@@ -3,7 +3,7 @@
 		<RootNamespace>Wolfgang.DbContextBuilderCore</RootNamespace>
 		<TargetFramework>net9.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<Version>0.6.0</Version>
+		<Version>0.6.1</Version>
 		<Title>Wolfgang.DbContextBuilder for EF Core 9</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>

--- a/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
@@ -3,7 +3,7 @@
 		<RootNamespace>Wolfgang.DbContextBuilderCore</RootNamespace>
 		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<Version>0.6.0</Version>
+		<Version>0.6.1</Version>
 		<Title>Wolfgang.DbContextBuilder for EF</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>

--- a/src/Wolfgang.DbContextBuilder-EF6/Wolfgang.DbContextBuilder-EF6.csproj
+++ b/src/Wolfgang.DbContextBuilder-EF6/Wolfgang.DbContextBuilder-EF6.csproj
@@ -3,7 +3,7 @@
 		<RootNamespace>Wolfgang.DbContextBuilderEF6</RootNamespace>
 		<TargetFrameworks>net462;net47;net471;net472;net48;net481</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
-		<Version>0.6.0</Version>
+		<Version>0.6.1</Version>
 		<Title>Wolfgang.DbContextBuilder for Entity Framework 6</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database with Entity Framework 6</Description>


### PR DESCRIPTION
## Summary
Bumps all 7 csproj `<Version>` entries from `0.6.0` to `0.6.1`. Skipping straight to `0.6.1` because the `v0.6.0` git tag exists from earlier failed release attempts but the corresponding GitHub Release was deleted (assets couldn't be uploaded due to immutable-release rejection — see #194 for the workflow fix).

## Files changed
- `src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj`
- `src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj`
- `src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj`
- `src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj`
- `src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj`
- `src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj`
- `src/Wolfgang.DbContextBuilder-EF6/Wolfgang.DbContextBuilder-EF6.csproj`

7 files changed, 7 insertions(+), 7 deletions(-)

## Order of operations
1. Merge #194 first (workflow fix — tag-push trigger)
2. Merge this PR
3. `git tag v0.6.1 && git push origin v0.6.1` — workflow will create v0.6.1 GitHub Release with assets attached, push packages to NuGet

## Test plan
- [ ] After both PRs merge, push v0.6.1 tag and verify the workflow creates the release end-to-end with `.nupkg` / `.bom.json` / coverage zip attached
- [ ] Verify packages appear on NuGet