### PR TITLE
chore: address Copilot review on #196 — sync .gitattributes, .editorconfig, and Setup-Labels shebang from canonical

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,14 +25,12 @@ indent_size = 2
 [*.{yml,yaml}]
 indent_size = 2
 
-# PowerShell files
-# Only the indent override is needed; LF + UTF-8 (no BOM) come from the
-# global [*] section above. LF + no-BOM is required for the
-# `#!/usr/bin/env pwsh` shebang at the top of every script in scripts/
-# to work on Linux/macOS — CR breaks the kernel's exec lookup, and a
-# leading BOM prevents shebang recognition entirely.
-[*.ps1]
-indent_size = 4
+# PowerShell scripts inherit LF + UTF-8 (no BOM) + 4-space indent from
+# the global [*] section above — no per-language override is needed.
+# LF + no-BOM is required for the `#!/usr/bin/env pwsh` shebang at the
+# top of every script in scripts/ to work on Linux/macOS — CR breaks
+# the kernel's exec lookup, and a leading BOM prevents shebang
+# recognition entirely.
 
 # C# files
 [*.cs]

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,13 +9,16 @@
 *.fsx text eol=lf
 
 # Scripts
-# PowerShell scripts: LF line endings, no BOM. Required for the
+# PowerShell scripts: enforce LF line endings in both the index AND
+# the working tree (the explicit `eol=lf` overrides any user-level
+# `core.autocrlf=true` setting that would otherwise convert to CRLF
+# on checkout). BOM-free UTF-8 encoding is enforced separately by
+# .editorconfig's global `charset = utf-8` — .gitattributes can only
+# control EOL, not byte-order marks. LF is required for the
 # `#!/usr/bin/env pwsh` shebang to work on Linux/macOS — the kernel
 # parses CR as part of the interpreter name (looking for `pwsh\r`),
-# and a UTF-8 BOM before `#!` prevents shebang recognition entirely.
-# Modern PowerShell 7+ handles LF on Windows transparently; Git's
-# autocrlf still gives Windows users CRLF in their working tree if
-# desired without forcing CRLF into the index.
+# and a UTF-8 BOM before `#!` would prevent shebang recognition
+# entirely. Modern PowerShell 7+ handles LF on Windows transparently.
 *.ps1 text eol=lf
 
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -13,8 +13,10 @@
 # the working tree (the explicit `eol=lf` overrides any user-level
 # `core.autocrlf=true` setting that would otherwise convert to CRLF
 # on checkout). BOM-free UTF-8 encoding is enforced separately by
-# .editorconfig's global `charset = utf-8` — .gitattributes can only
-# control EOL, not byte-order marks. LF is required for the
+# .editorconfig's global `charset = utf-8` — `.gitattributes` can
+# normalize line endings (and control text/binary, diff, and merge
+# behavior) but has no attribute for byte-order marks. LF is required
+# for the
 # `#!/usr/bin/env pwsh` shebang to work on Linux/macOS — the kernel
 # parses CR as part of the interpreter name (looking for `pwsh\r`),
 # and a UTF-8 BOM before `#!` would prevent shebang recognition

--- a/scripts/Setup-Labels.ps1
+++ b/scripts/Setup-Labels.ps1
@@ -1,3 +1,4 @@
+#!/usr/bin/env pwsh
 <#
 .SYNOPSIS
     Creates custom GitHub labels for the repository.


### PR DESCRIPTION
## Summary
Addresses the four Copilot review threads on the merged [#196](https://github.com/Chris-Wolfgang/DbContextBuilder/pull/196) by syncing from current `repo-template` canonical.

#196 landed the LF EOL switch, but its `.gitattributes` / `.editorconfig` wording predated clarifications since pushed to the template. Copilot's four comments all point at the older wording.

### Changes
- **`.gitattributes`** — canonical now spells out: BOM enforcement is via `.editorconfig`'s `charset = utf-8` (not `.gitattributes`), and `eol=lf` overrides `core.autocrlf`, not the reverse. Resolves both `.gitattributes:18` threads.
- **`.editorconfig`** — canonical drops the redundant `[*.ps1] indent_size = 4` block; the global `[*]` already sets `indent_size = 4`. Resolves the "indent override is redundant" thread on `.editorconfig:35`.
- **`scripts/Setup-Labels.ps1`** — add the missing `#!/usr/bin/env pwsh` shebang. The `.editorconfig` comment claims every script in `scripts/` has one; this script was the only divergent file. Resolves the `.editorconfig:33` thread.

Same recipe was applied to String-Extensions in [PR #49](https://github.com/Chris-Wolfgang/String-Extensions/pull/49) (its review threads were resolved).

## CI expectation
"Detect .NET Projects" will fail because `.editorconfig` is in the protected-config-files list — same intentional guard you've been overriding on the BOM backport PRs. Diff is 3 files / +15 / -13, all workflow-and-config edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)