### PR TITLE
fix: restore <AssemblyVersion>1.0.0.0</AssemblyVersion> across all src csprojs (C4 post-mortem)

### DIFF
--- a/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
@@ -4,6 +4,13 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Version>0.6.1</Version>
+		<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
+		     do not need to recompile / add binding redirects on every minor/patch
+		     bump. Bump only on a deliberate breaking API change. FileVersion +
+		     InformationalVersion (the latter auto-derived from <Version>) carry
+		     the actual release version. -->
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
 		<Title>Wolfgang.DbContextBuilder for EF Core 10</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>

--- a/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
@@ -4,6 +4,13 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Version>0.6.1</Version>
+		<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
+		     do not need to recompile / add binding redirects on every minor/patch
+		     bump. Bump only on a deliberate breaking API change. FileVersion +
+		     InformationalVersion (the latter auto-derived from <Version>) carry
+		     the actual release version. -->
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
 		<Title>Wolfgang.DbContextBuilder for EF Core 6</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>

--- a/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
@@ -4,6 +4,13 @@
 		<TargetFramework>net7.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Version>0.6.1</Version>
+		<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
+		     do not need to recompile / add binding redirects on every minor/patch
+		     bump. Bump only on a deliberate breaking API change. FileVersion +
+		     InformationalVersion (the latter auto-derived from <Version>) carry
+		     the actual release version. -->
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
 		<Title>Wolfgang.DbContextBuilder for EF Core 7</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>

--- a/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
@@ -4,6 +4,13 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Version>0.6.1</Version>
+		<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
+		     do not need to recompile / add binding redirects on every minor/patch
+		     bump. Bump only on a deliberate breaking API change. FileVersion +
+		     InformationalVersion (the latter auto-derived from <Version>) carry
+		     the actual release version. -->
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
 		<Title>Wolfgang.DbContextBuilder for EF Core 8</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>

--- a/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
@@ -4,6 +4,13 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Version>0.6.1</Version>
+		<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
+		     do not need to recompile / add binding redirects on every minor/patch
+		     bump. Bump only on a deliberate breaking API change. FileVersion +
+		     InformationalVersion (the latter auto-derived from <Version>) carry
+		     the actual release version. -->
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
 		<Title>Wolfgang.DbContextBuilder for EF Core 9</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>

--- a/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
@@ -4,6 +4,13 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Version>0.6.1</Version>
+		<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
+		     do not need to recompile / add binding redirects on every minor/patch
+		     bump. Bump only on a deliberate breaking API change. FileVersion +
+		     InformationalVersion (the latter auto-derived from <Version>) carry
+		     the actual release version. -->
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
 		<Title>Wolfgang.DbContextBuilder for EF</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database</Description>

--- a/src/Wolfgang.DbContextBuilder-EF6/Wolfgang.DbContextBuilder-EF6.csproj
+++ b/src/Wolfgang.DbContextBuilder-EF6/Wolfgang.DbContextBuilder-EF6.csproj
@@ -4,6 +4,13 @@
 		<TargetFrameworks>net462;net47;net471;net472;net48;net481</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<Version>0.6.1</Version>
+		<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
+		     do not need to recompile / add binding redirects on every minor/patch
+		     bump. Bump only on a deliberate breaking API change. FileVersion +
+		     InformationalVersion (the latter auto-derived from <Version>) carry
+		     the actual release version. -->
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
 		<Title>Wolfgang.DbContextBuilder for Entity Framework 6</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A library for easily building DbContext for testing using in-memory database with Entity Framework 6</Description>


### PR DESCRIPTION
Restores `<AssemblyVersion>1.0.0.0</AssemblyVersion>` + adds prerelease-safe `<FileVersion>` (via regex-strip property function) to **every src csproj** in this multi-project repo.

## Why

The original C4 fanout dropped `<AssemblyVersion>` on the rationale that the hardcoded `1.0.0` was "stale" relative to released package versions. But that staleness was the **correct** binding-stability behaviour for libraries that ship a `net462` TFM. With SDK-derived AssemblyVersion, every minor/patch release ships a different binding identity, breaking .NET Framework consumers without a binding redirect.

DateTime-Extensions v1.3.0 publicly shipped this regression. **This repo has not yet released the regression** (the C4 drop is on `canonical-unprotected` but hasn't reached `main`). Landing this fix neutralises the footgun across all src csprojs before any merge to main.

## Csproj changes (per src project)

```diff
  <Version>...</Version>
+ <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
+      do not need to recompile / add binding redirects on every minor/patch
+      bump. Bump only on a deliberate breaking API change. FileVersion +
+      InformationalVersion (the latter auto-derived from <Version>) carry
+      the actual release version. -->
+ <AssemblyVersion>1.0.0.0</AssemblyVersion>
+ <FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
```

The regex-strip property function ensures prerelease `<Version>` values (e.g., `1.2.3-beta.1`) still produce a 4-part numeric `AssemblyFileVersion` (`1.2.3.0`) — verified locally on peer repos.

## Standard pattern (NodaTime / Newtonsoft / AutoMapper)

| Property | Bumps on | Example |
|---|---|---|
| `AssemblyVersion` | **breaking change only** | `1.0.0.0` |
| `AssemblyFileVersion` | every release | `<Version>.0` |
| `Version` (NuGet) | every release | `<Version>` |

Tracked in the per-repo-release-pilot skill as the corrected Phase 2 step 1.