### PR TITLE
D1 csproj cleanup: consolidate dupe GenerateDocumentationFile+NoWarn blocks

### DIFF
--- a/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
@@ -21,6 +21,7 @@
 		<PackageIcon>dbcontext-builder.png</PackageIcon>
 		<ApplicationIcon>dbcontext-builder.ico</ApplicationIcon>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);1591</NoWarn>
 		<SignAssembly>False</SignAssembly>
 		<PackageTags></PackageTags>
 
@@ -75,11 +76,6 @@
                 <Content Include="..\Wolfgang.DbContextBuilder-Core\Content\dbcontext-builder-inverted.png" Link="Content\dbcontext-builder-inverted.png" />
                 <Content Include="dbcontext-builder.ico" Link="Content\dbcontext-builder.ico" />
 	</ItemGroup>
-
-	 <PropertyGroup>
-		 <GenerateDocumentationFile>true</GenerateDocumentationFile>
-		 <NoWarn>$(NoWarn);1591</NoWarn>
-	 </PropertyGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
 

--- a/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
@@ -21,6 +21,7 @@
 		<PackageIcon>dbcontext-builder.png</PackageIcon>
 		<ApplicationIcon>dbcontext-builder.ico</ApplicationIcon>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);1591</NoWarn>
 		<SignAssembly>False</SignAssembly>
 		<PackageTags></PackageTags>
 
@@ -74,11 +75,6 @@
                 <Content Include="..\Wolfgang.DbContextBuilder-Core\Content\dbcontext-builder-inverted.png" Link="Content\dbcontext-builder-inverted.png" />
                 <Content Include="dbcontext-builder.ico" Link="Content\dbcontext-builder.ico" />
 	</ItemGroup>
-
-	 <PropertyGroup>
-		 <GenerateDocumentationFile>true</GenerateDocumentationFile>
-		 <NoWarn>$(NoWarn);1591</NoWarn>
-	 </PropertyGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
 

--- a/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
@@ -21,6 +21,7 @@
 		<PackageIcon>dbcontext-builder.png</PackageIcon>
 		<ApplicationIcon>dbcontext-builder.ico</ApplicationIcon>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);1591</NoWarn>
 		<SignAssembly>False</SignAssembly>
 		<PackageTags></PackageTags>
 
@@ -74,11 +75,6 @@
                 <Content Include="..\Wolfgang.DbContextBuilder-Core\Content\dbcontext-builder-inverted.png" Link="Content\dbcontext-builder-inverted.png" />
                 <Content Include="dbcontext-builder.ico" Link="Content\dbcontext-builder.ico" />
 	</ItemGroup>
-
-	 <PropertyGroup>
-		 <GenerateDocumentationFile>true</GenerateDocumentationFile>
-		 <NoWarn>$(NoWarn);1591</NoWarn>
-	 </PropertyGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
 

--- a/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
@@ -21,6 +21,7 @@
 		<PackageIcon>dbcontext-builder.png</PackageIcon>
 		<ApplicationIcon>dbcontext-builder.ico</ApplicationIcon>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);1591</NoWarn>
 		<SignAssembly>False</SignAssembly>
 		<PackageTags></PackageTags>
 
@@ -74,11 +75,6 @@
                 <Content Include="..\Wolfgang.DbContextBuilder-Core\Content\dbcontext-builder-inverted.png" Link="Content\dbcontext-builder-inverted.png" />
                 <Content Include="dbcontext-builder.ico" Link="Content\dbcontext-builder.ico" />
 	</ItemGroup>
-
-	 <PropertyGroup>
-		 <GenerateDocumentationFile>true</GenerateDocumentationFile>
-		 <NoWarn>$(NoWarn);1591</NoWarn>
-	 </PropertyGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
 

--- a/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
@@ -21,6 +21,7 @@
 		<PackageIcon>dbcontext-builder.png</PackageIcon>
 		<ApplicationIcon>dbcontext-builder.ico</ApplicationIcon>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);1591</NoWarn>
 		<SignAssembly>False</SignAssembly>
 		<PackageTags></PackageTags>
 
@@ -77,11 +78,6 @@
                 <Content Include="..\Wolfgang.DbContextBuilder-Core\Content\dbcontext-builder-inverted.png" Link="Content\dbcontext-builder-inverted.png" />
                 <Content Include="dbcontext-builder.ico" Link="Content\dbcontext-builder.ico" />
 	</ItemGroup>
-
-	 <PropertyGroup>
-		 <GenerateDocumentationFile>true</GenerateDocumentationFile>
-		 <NoWarn>$(NoWarn);1591</NoWarn>
-	 </PropertyGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
 

--- a/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
@@ -21,6 +21,7 @@
 		<PackageIcon>dbcontext-builder.png</PackageIcon>
 		<ApplicationIcon>Content/dbcontext-builder.ico</ApplicationIcon>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);1591</NoWarn>
 		<SignAssembly>False</SignAssembly>
 		<PackageTags></PackageTags>
 
@@ -49,11 +50,6 @@
 		<None Include="Content\dbcontext-builder.png" Pack="true" PackagePath="/" />
 		<None Include="Content\dbcontext-builder.ico" Pack="true" PackagePath="/" />
 	</ItemGroup>
-
-	 <PropertyGroup>
-		 <GenerateDocumentationFile>true</GenerateDocumentationFile>
-		 <NoWarn>$(NoWarn);1591</NoWarn>
-	 </PropertyGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
 

--- a/src/Wolfgang.DbContextBuilder-EF6/Wolfgang.DbContextBuilder-EF6.csproj
+++ b/src/Wolfgang.DbContextBuilder-EF6/Wolfgang.DbContextBuilder-EF6.csproj
@@ -20,6 +20,7 @@
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<PackageIcon>dbcontext-builder.png</PackageIcon>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);1591</NoWarn>
 		<SignAssembly>False</SignAssembly>
 		<PackageTags></PackageTags>
 		<IsPackable>true</IsPackable>
@@ -49,11 +50,6 @@
 		<Content Include="..\Wolfgang.DbContextBuilder-Core\Content\dbcontext-builder.png" Link="Content\dbcontext-builder.png" />
 		<Content Include="..\Wolfgang.DbContextBuilder-Core\Content\dbcontext-builder-inverted.png" Link="Content\dbcontext-builder-inverted.png" />
 	</ItemGroup>
-
-	<PropertyGroup>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<NoWarn>$(NoWarn);1591</NoWarn>
-	</PropertyGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
 


### PR DESCRIPTION
## Summary

Each src csproj had two PropertyGroup blocks setting
`<GenerateDocumentationFile>` — one in the main metadata group and a
second redundant group lower in the file. The `<NoWarn>$(NoWarn);1591</NoWarn>`
suppression lived only in the second block, making the layout
confusing and dupe-prone.

Collapse to a single canonical pair in the main PropertyGroup of each
src csproj (7 files):
```
<GenerateDocumentationFile>True</GenerateDocumentationFile>
<NoWarn>$(NoWarn);1591</NoWarn>
```

No behavioral change. XML doc generation stays on; CS1591 (missing
XML doc on public member) stays suppressed.

## Partial close on #219

Closing the actual XML-doc gaps (writing the missing `<summary>` and
`<param>` blocks across the public surface so the CS1591 suppression
can be removed) is engineering-heavy and tracked separately as the
remaining scope of #219.

Stacked on top of vNext (PR #242).