### PR TITLE
Cleanup: remove commented-out test method (closes #211)

### DIFF
--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteForMsSqlServerModelCustomizerTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteForMsSqlServerModelCustomizerTests.cs
@@ -276,26 +276,6 @@ public class SqliteForMsSqlServerModelCustomizerTests
 
 
 
-    ///// <summary>
-    ///// Verifies that the default implementation for OverrideComputedValueHandling does_nothing
-    ///// </summary>
-    //[Fact]
-    //public void OverrideComputedValueHandling_default_implementation_set_default_to_null()
-    //{
-    //    // Arrange
-    //    var finder = new Mock<IDbSetFinder>().Object;
-    //    var dependencies = new ModelCustomizerDependencies(finder);
-    //    var sut = new SqliteForMsSqlServerModelCustomizer(dependencies);
-
-    //    // Act & Assert
-    //    Assert.Equal("(isnull('AW'+[dbo].[ufnLeadingZeros]([CustomerID]),''))", sut.OverrideComputedValueHandling("(isnull('AW'+[dbo].[ufnLeadingZeros]([CustomerID]),''))"));
-    //    Assert.Equal("([OrganizationNode].[GetLevel]())", sut.OverrideComputedValueHandling("([OrganizationNode].[GetLevel]())"));
-    //    Assert.Equal("", sut.OverrideComputedValueHandling(""));
-    //    Assert.Equal(null, sut.OverrideComputedValueHandling(null));
-    //}
-
-
-
     /// <summary>
     /// Verifies OverrideComputedValueHandling honors custom implementation when specified.
     /// </summary>


### PR DESCRIPTION
## Summary

Removes the only piece of dead code surfaced by the #211 sweep across
`src/`, `tests/`, and `benchmarks/`.

## Removed

`tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteForMsSqlServerModelCustomizerTests.cs`
contained a fully commented-out `[Fact]` method
(`OverrideComputedValueHandling_default_implementation_set_default_to_null`).
Per the project convention — *commented-out code is never kept;
git history is the archive* — the block is removed.

The live test
`OverrideComputedValueHandling_uses_custom_method_when_provided`
remains and exercises the same surface for the custom-override
branch.

## Other findings (kept)

- `tests/.../TestConstants.cs:11` has a TODO about `MaxTestRuntimeMs`
  optimization. Real outstanding work; not dead code; left in place.
- All `private`/`internal` helpers in test files
  (`NoProviderDbContextCreator`, `TableMetadata`, `ColumnMetadata`,
  `GetTableMetadataAsync`, `GetColumnMetadataAsync`, `GetTableNamesAsync`,
  `CreateDbContextBuilder`) are referenced by active tests.
- No unreferenced `[Fact]` / `[Theory]` methods detected.
- No commented-out code in `src/`.

Stacked on top of vNext (PR #242).