### PR TITLE
C5 code review pass: minor XML doc + naming cleanup (closes #210)

### DIFF
--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
@@ -6,6 +6,7 @@ namespace Wolfgang.DbContextBuilderCore;
 /// <summary>
 /// Uses the Builder pattern to create instances of DbContext types seeded with specified data.
 /// </summary>
+/// <typeparam name="T">The concrete <see cref="DbContext"/> type to construct.</typeparam>
 /// <remarks>
 /// When using the SQLite provider, the builder holds an open SQLite in-memory connection.
 /// Dispose the builder only after all <see cref="DbContext"/> instances returned by
@@ -89,8 +90,8 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
             throw new ArgumentException("The type of TEntity cannot be string", nameof(entities));
         }
 
-        var enumerable = entities as TEntity[] ?? entities.ToArray();
-        return SeedWith(enumerable);
+        var entityArray = entities as TEntity[] ?? entities.ToArray();
+        return SeedWith(entityArray);
     }
 
 
@@ -98,8 +99,8 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// <summary>
     /// Populates the specified DbSet with the provided entities.
     /// </summary>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
     /// <param name="entities">The entities to populate the database with</param>
+    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
     /// <exception cref="ArgumentNullException">entities is null</exception>
     /// <exception cref="ArgumentException">entities contains a null item</exception>
     /// <exception cref="ArgumentException">entities contains a string</exception>
@@ -210,9 +211,9 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
 
 
     /// <summary>
-    /// Creates a new instance of T seeded with specified data.
+    /// Creates a new instance of <typeparamref name="T"/> seeded with the specified data.
     /// </summary>
-    /// <returns>instance of {T}</returns>
+    /// <returns>A new instance of <typeparamref name="T"/>.</returns>
     /// <exception cref="NotSupportedException">The specified database provider is not supported</exception>
     /// <exception cref="ObjectDisposedException">The builder has been disposed.</exception>
     public async Task<T> BuildAsync()


### PR DESCRIPTION
## Summary

C5 / #210 — full AI code-review pass across all 11 src files in
`Wolfgang.DbContextBuilder-Core/` (~1,000 LOC including `DbContextBuilder.cs`
at 291 lines and `SqliteModelCustomizer.cs` at 259 lines).

**Overall verdict:** code is in very good shape. Modern C# (Allman,
ArgumentNullException.ThrowIfNull, async/await with ConfigureAwait,
switch expressions), no banned-API trips, no allocation hot spots in
measured paths, no obvious correctness bugs.

## Fixed in this PR

1. **`DbContextBuilder<T>` class** — missing `<typeparam name="T"/>` doc
   on the class declaration. Added.
2. **`DbContextBuilder.cs:92`** — local variable named `enumerable` was
   actually a `TEntity[]` array (after the `as TEntity[] ?? .ToArray()`
   reduction). Renamed to `entityArray`.
3. **`SeedWith` params overload XML doc** — had `<returns>` before
   `<param>`, inconsistent with sibling overloads. Reordered to
   `<param>` then `<returns>`.
4. **`BuildAsync` XML doc** — `'{T}'` literal in `<returns>` replaced
   with `<typeparamref name="T"/>` so DocFX renders it as a proper
   cross-reference.

## Findings reviewed but NOT changed (with reasoning)

- **Redundant-looking string check in `SeedWith<IEnumerable>`** — the
  early `typeof(TEntity) == typeof(string)` check short-circuits before
  materializing the IEnumerable, while the params overload's
  `case string:` catches the per-element variant. Both kept; they
  complement rather than duplicate.
- **Two contexts in `BuildAsync`** — intentional pattern (seed-context
  disposed, return-context returned) that works correctly for both
  InMemory and Sqlite shared-connection providers.
- **`Assert.True(buffer.Length > 0, ...)` in tests** — covered by the
  T4 audit on #239; kept for the custom failure message which
  `Assert.NotEmpty` would lose.
- **`AutoFixtureRandomEntityCreator`, `SqliteModelCustomizer`,
  `SqliteForMsSqlServerModelCustomizer`** — read in full, no findings.

Stacked on top of vNext.