### PR TITLE
P2: benchmarks.yaml — publish BDN chart to gh-pages /dev/bench/ (closes #213)

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,111 @@
+name: Benchmarks
+
+# Runs BenchmarkDotNet after a merge to main, then publishes the results to
+# the gh-pages branch under /dev/bench/ where benchmark-action/github-action-benchmark
+# renders an interactive line chart.
+#
+# This workflow is decoupled from PR validation and release: it does NOT gate
+# merging or publishing — it just adds one data point per qualifying push.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'benchmarks/**'
+      - '.github/workflows/benchmarks.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialize all writes to the gh-pages branch — both within this workflow
+# (two main pushes close together) and across workflows that also publish
+# to gh-pages (docfx.yaml, release.yaml). The shared `gh-pages` group name
+# means GitHub Actions queues any of those jobs behind the others when
+# they overlap, preventing non-fast-forward push failures and lost
+# updates. cancel-in-progress: false — every merge represents a meaningful
+# data point, so we queue rather than discard.
+#
+# NOTE: docfx.yaml and release.yaml currently have no `concurrency:` block,
+# so cross-workflow serialization is only partial today. Adding the same
+# `gh-pages` group to those workflows is tracked as a fleet-wide follow-up.
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    name: Run BenchmarkDotNet & publish chart
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Required to push the rendered chart + history to the gh-pages branch.
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore benchmarks/DbContextBuilder.Benchmarks/DbContextBuilder.Benchmarks.csproj
+
+      - name: Build (Release)
+        run: dotnet build -c Release --no-restore benchmarks/DbContextBuilder.Benchmarks/DbContextBuilder.Benchmarks.csproj
+
+      - name: Run benchmarks
+        working-directory: benchmarks/DbContextBuilder.Benchmarks
+        # ShortRun keeps total runtime small (~3-5 min). GitHub-hosted runners
+        # are noisy, so chart trends are reliable for allocations and double-digit
+        # time changes; smaller deltas are not.
+        run: dotnet run -c Release --no-build -- --filter "*" --job short --memory --exporters json
+
+      - name: Merge per-class BDN reports
+        id: locate
+        working-directory: benchmarks/DbContextBuilder.Benchmarks
+        run: |
+          # BDN's --exporters json writes one *-report-full-compressed.json per
+          # benchmark class. github-action-benchmark consumes a single file, so
+          # we combine the .Benchmarks arrays into one synthetic report.
+          # nullglob: empty match expands to nothing (instead of the literal
+          # pattern), so the explicit "no report found" branch can run before
+          # set -e + pipefail aborts the step.
+          shopt -s nullglob
+          reports=(BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json)
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "::error::No BenchmarkDotNet JSON report found"
+            exit 1
+          fi
+          echo "Merging ${#reports[@]} report(s):"
+          printf '  %s\n' "${reports[@]}"
+          jq -s '{
+            Title: "BenchmarkDotNet combined report",
+            HostEnvironmentInfo: .[0].HostEnvironmentInfo,
+            Benchmarks: [.[].Benchmarks[]]
+          }' "${reports[@]}" > benchmarks-result.json
+          echo "report=benchmarks/DbContextBuilder.Benchmarks/benchmarks-result.json" >> "$GITHUB_OUTPUT"
+
+      - name: Publish chart to gh-pages
+        # Pinned to v1.22.1 commit per repo convention (third-party actions
+        # publishing to gh-pages are pinned by SHA, not mutable tag).
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba  # v1.22.1
+        with:
+          name: BenchmarkDotNet
+          tool: 'benchmarkdotnet'
+          output-file-path: ${{ steps.locate.outputs.report }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Don't fail the workflow if a metric regresses — this is a tracker,
+          # not a gate. Tighten later if the noise floor settles.
+          alert-threshold: '200%'
+          fail-on-alert: false

--- a/Wolfgang.DbContextBuilder.sln
+++ b/Wolfgang.DbContextBuilder.sln
@@ -48,6 +48,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wolfgang.DbContextBuilder-E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbContextBuilder.Benchmarks", "benchmarks\DbContextBuilder.Benchmarks\DbContextBuilder.Benchmarks.csproj", "{09C67864-5269-48D5-ABC1-0B6D829BDC32}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Wolfgang.DbContextBuilder.sln
+++ b/Wolfgang.DbContextBuilder.sln
@@ -46,6 +46,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wolfgang.DbContextBuilder-E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wolfgang.DbContextBuilder-EF6.Tests.Unit", "tests\Wolfgang.DbContextBuilder-EF6.Tests.Unit\Wolfgang.DbContextBuilder-EF6.Tests.Unit.csproj", "{1E7E5895-D26D-434D-A5FD-4F592671F033}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbContextBuilder.Benchmarks", "benchmarks\DbContextBuilder.Benchmarks\DbContextBuilder.Benchmarks.csproj", "{09C67864-5269-48D5-ABC1-0B6D829BDC32}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -248,6 +250,18 @@ Global
 		{1E7E5895-D26D-434D-A5FD-4F592671F033}.Release|x64.Build.0 = Release|Any CPU
 		{1E7E5895-D26D-434D-A5FD-4F592671F033}.Release|x86.ActiveCfg = Release|Any CPU
 		{1E7E5895-D26D-434D-A5FD-4F592671F033}.Release|x86.Build.0 = Release|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Debug|x64.Build.0 = Debug|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Debug|x86.Build.0 = Debug|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Release|x64.ActiveCfg = Release|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Release|x64.Build.0 = Release|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Release|x86.ActiveCfg = Release|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -269,6 +283,7 @@ Global
 		{3F464DBA-C84F-E522-8B80-5E7CDA76083E} = {FE76EF26-2FEF-446B-B219-AEE9E697D0ED}
 		{D4D27C53-4517-4939-9C40-38A6ECB77593} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{1E7E5895-D26D-434D-A5FD-4F592671F033} = {FE76EF26-2FEF-446B-B219-AEE9E697D0ED}
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32} = {52730BC6-6157-4CCF-BABE-146F614568D3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {31C82D45-4E67-40D9-821C-1C2E54B0DF63}

--- a/Wolfgang.DbContextBuilder.sln
+++ b/Wolfgang.DbContextBuilder.sln
@@ -48,8 +48,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wolfgang.DbContextBuilder-E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbContextBuilder.Benchmarks", "benchmarks\DbContextBuilder.Benchmarks\DbContextBuilder.Benchmarks.csproj", "{09C67864-5269-48D5-ABC1-0B6D829BDC32}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/benchmarks/DbContextBuilder.Benchmarks/BenchmarkContext.cs
+++ b/benchmarks/DbContextBuilder.Benchmarks/BenchmarkContext.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolfgang.DbContextBuilderCore.Benchmarks;
+
+/// <summary>
+/// Minimal entity used by the benchmark scenarios. Kept deliberately small
+/// (one scalar property beyond the id) so the per-row cost reflects
+/// DbContextBuilder overhead rather than entity-shape overhead.
+/// </summary>
+public sealed class BenchmarkEntity
+{
+    /// <summary>Primary key.</summary>
+    public int Id { get; set; }
+
+    /// <summary>A representative scalar property.</summary>
+    public string Name { get; set; } = string.Empty;
+}
+
+
+
+/// <summary>
+/// Minimal <see cref="DbContext"/> used by the benchmark scenarios. One
+/// DbSet of <see cref="BenchmarkEntity"/> is enough to exercise the full
+/// build + seed + SaveChanges path without dragging in the cost of a
+/// realistic multi-entity schema.
+/// </summary>
+public sealed class BenchmarkContext(DbContextOptions<BenchmarkContext> options)
+    : DbContext(options)
+{
+    /// <summary>The entity set populated by benchmark seed scenarios.</summary>
+    public DbSet<BenchmarkEntity> Entities => Set<BenchmarkEntity>();
+}

--- a/benchmarks/DbContextBuilder.Benchmarks/BuildAsyncBenchmarks.cs
+++ b/benchmarks/DbContextBuilder.Benchmarks/BuildAsyncBenchmarks.cs
@@ -1,0 +1,95 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Wolfgang.DbContextBuilderCore.Benchmarks;
+
+/// <summary>
+/// Baseline microbenchmarks for <see cref="DbContextBuilder{T}.BuildAsync"/>
+/// across the most common usage shapes. Scenarios:
+///
+/// <list type="bullet">
+///   <item><c>InMemory_NoSeed</c> — empty options, no data seeded.</item>
+///   <item><c>InMemory_SeedWith_N</c> — N pre-built entities seeded via
+///   <see cref="DbContextBuilder{T}.SeedWith{TEntity}(TEntity[])"/>.</item>
+///   <item><c>InMemory_SeedWithRandom_N</c> — N AutoFixture-generated
+///   entities seeded via
+///   <see cref="DbContextBuilder{T}.SeedWithRandom{TEntity}(int)"/>.</item>
+/// </list>
+///
+/// MemoryDiagnoser is on so allocation regressions surface in the gh-pages
+/// benchmark chart immediately.
+///
+/// Each benchmark disposes the constructed <see cref="BenchmarkContext"/>
+/// before returning so successive iterations don't accumulate in-memory
+/// databases or tracked entities that would distort the allocation
+/// measurements.
+/// </summary>
+[MemoryDiagnoser]
+public class BuildAsyncBenchmarks
+{
+    /// <summary>
+    /// Row counts for the seed scenarios. Kept small (1, 10, 100) so the
+    /// chart shows the per-row component of build cost without dominating
+    /// runtime.
+    /// </summary>
+    [Params(1, 10, 100)]
+    public int SeedCount { get; set; }
+
+    private BenchmarkEntity[] _seedRows = [];
+
+    /// <summary>
+    /// Pre-builds the <see cref="BenchmarkEntity"/> array once per
+    /// SeedCount value so the <c>SeedWith</c> benchmark measures only the
+    /// builder cost, not entity construction.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _seedRows = new BenchmarkEntity[SeedCount];
+        for (var i = 0; i < SeedCount; i++)
+        {
+            _seedRows[i] = new BenchmarkEntity { Id = i + 1, Name = $"row-{i + 1}" };
+        }
+    }
+
+
+
+    /// <summary>
+    /// Baseline: builder with default options (InMemory provider), no seed.
+    /// Measures the irreducible cost of <see cref="DbContextBuilder{T}.BuildAsync"/>.
+    /// </summary>
+    [Benchmark(Baseline = true)]
+    public async Task InMemory_NoSeed()
+    {
+        using var builder = new DbContextBuilder<BenchmarkContext>();
+        await using var context = await builder.BuildAsync().ConfigureAwait(false);
+    }
+
+
+
+    /// <summary>
+    /// Builder with <c>SeedCount</c> pre-built entities seeded via
+    /// <see cref="DbContextBuilder{T}.SeedWith{TEntity}(TEntity[])"/>.
+    /// </summary>
+    [Benchmark]
+    public async Task InMemory_SeedWith()
+    {
+        using var builder = new DbContextBuilder<BenchmarkContext>()
+            .SeedWith(_seedRows);
+        await using var context = await builder.BuildAsync().ConfigureAwait(false);
+    }
+
+
+
+    /// <summary>
+    /// Builder with <c>SeedCount</c> AutoFixture-generated entities seeded
+    /// via <see cref="DbContextBuilder{T}.SeedWithRandom{TEntity}(int)"/>.
+    /// Captures the AutoFixture cost on top of the baseline.
+    /// </summary>
+    [Benchmark]
+    public async Task InMemory_SeedWithRandom()
+    {
+        using var builder = new DbContextBuilder<BenchmarkContext>()
+            .SeedWithRandom<BenchmarkEntity>(SeedCount);
+        await using var context = await builder.BuildAsync().ConfigureAwait(false);
+    }
+}

--- a/benchmarks/DbContextBuilder.Benchmarks/DbContextBuilder.Benchmarks.csproj
+++ b/benchmarks/DbContextBuilder.Benchmarks/DbContextBuilder.Benchmarks.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Wolfgang.DbContextBuilderCore.Benchmarks</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.DbContextBuilder-Core\Wolfgang.DbContextBuilder-Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+</Project>

--- a/benchmarks/DbContextBuilder.Benchmarks/Program.cs
+++ b/benchmarks/DbContextBuilder.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);


### PR DESCRIPTION
## Summary

Adds the canonical benchmarks workflow that runs BenchmarkDotNet on
qualifying pushes to main and publishes the chart to
\`gh-pages /dev/bench/\` via \`benchmark-action/github-action-benchmark\`.

Verbatim canonical sync from DateTime-Extensions / repo-template, with
paths substituted for **\`DbContextBuilder.Benchmarks\`** (the project
added by **#249 / P1**).

## Trigger

\`push\` to main when \`src/**\`, \`benchmarks/**\`, or this workflow
itself changes; also \`workflow_dispatch\`. Concurrency-grouped on
\`gh-pages\` to serialize against docfx.yaml and release.yaml writes.

## Job

1. Restore + build the benchmark project (Release).
2. \`dotnet run -- --filter "*" --job short --memory --exporters json\`
   — ShortRun keeps runtime ~3-5 min on GitHub-hosted runners.
3. Merge per-class BDN JSON reports into one combined report via \`jq\`.
4. Push the report to \`gh-pages /dev/bench/\` with
   \`benchmark-action/github-action-benchmark@52576c9 (v1.22.1)\` (SHA-pinned).
5. Not a release gate: \`fail-on-alert: false\`,
   \`alert-threshold: 200%\`.

## Stacked on

vNext → #249 (P1 baseline) → this PR. **Requires #249 to merge first**
or the workflow's restore step will fail (no benchmark csproj on vNext).

## Admin-bypass

Touches \`.github/workflows/benchmarks.yaml\` (protected path). Detect
.NET Projects will fail; admin-bypass merge needed.