### PR TITLE
Add curated benchmarks/.editorconfig (closes #234)

### DIFF
--- a/Wolfgang.DbContextBuilder.sln
+++ b/Wolfgang.DbContextBuilder.sln
@@ -46,6 +46,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wolfgang.DbContextBuilder-E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wolfgang.DbContextBuilder-EF6.Tests.Unit", "tests\Wolfgang.DbContextBuilder-EF6.Tests.Unit\Wolfgang.DbContextBuilder-EF6.Tests.Unit.csproj", "{1E7E5895-D26D-434D-A5FD-4F592671F033}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbContextBuilder.Benchmarks", "benchmarks\DbContextBuilder.Benchmarks\DbContextBuilder.Benchmarks.csproj", "{09C67864-5269-48D5-ABC1-0B6D829BDC32}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -248,6 +250,18 @@ Global
 		{1E7E5895-D26D-434D-A5FD-4F592671F033}.Release|x64.Build.0 = Release|Any CPU
 		{1E7E5895-D26D-434D-A5FD-4F592671F033}.Release|x86.ActiveCfg = Release|Any CPU
 		{1E7E5895-D26D-434D-A5FD-4F592671F033}.Release|x86.Build.0 = Release|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Debug|x64.Build.0 = Debug|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Debug|x86.Build.0 = Debug|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Release|x64.ActiveCfg = Release|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Release|x64.Build.0 = Release|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Release|x86.ActiveCfg = Release|Any CPU
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -269,6 +283,7 @@ Global
 		{3F464DBA-C84F-E522-8B80-5E7CDA76083E} = {FE76EF26-2FEF-446B-B219-AEE9E697D0ED}
 		{D4D27C53-4517-4939-9C40-38A6ECB77593} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{1E7E5895-D26D-434D-A5FD-4F592671F033} = {FE76EF26-2FEF-446B-B219-AEE9E697D0ED}
+		{09C67864-5269-48D5-ABC1-0B6D829BDC32} = {52730BC6-6157-4CCF-BABE-146F614568D3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {31C82D45-4E67-40D9-821C-1C2E54B0DF63}

--- a/benchmarks/.editorconfig
+++ b/benchmarks/.editorconfig
@@ -1,0 +1,47 @@
+# Curated analyzer suppressions for BenchmarkDotNet projects.
+#
+# Benchmark code deliberately violates a handful of analyzer rules that
+# would be bugs in production code. Suppressing them per-rule (rather
+# than disabling TreatWarningsAsErrors for the whole benchmarks/ tree)
+# keeps the rest of the analyzer suite live so genuine issues still
+# surface as build errors.
+#
+# Add new entries here when a new BDN-legitimate analyzer trips on
+# this repo's benchmark project. Do NOT widen the scope past benchmark-
+# specific patterns — production code should not benefit from these
+# carve-outs.
+
+root = false
+
+[*.cs]
+
+# CA1822: Mark members as static
+# BDN [Benchmark] methods MUST be instance methods so BenchmarkSwitcher
+# can instantiate the class per benchmark run and apply [GlobalSetup]/
+# [IterationSetup] state. Marking them static would break the harness.
+dotnet_diagnostic.CA1822.severity = none
+
+# S2325 (SonarAnalyzer) — same intent as CA1822 but Sonar's flavor.
+dotnet_diagnostic.S2325.severity = none
+
+# CA1707: Identifiers should not contain underscores
+# BDN convention uses `MethodName_VariantName` (e.g.
+# `InMemory_SeedWith`) so the published chart legend reads naturally.
+dotnet_diagnostic.CA1707.severity = none
+
+# S1144 (SonarAnalyzer): Unused private types or members should be removed
+# BDN classes / [GlobalSetup] / [Params] members are instantiated and
+# read by reflection — Sonar can't see those usage sites.
+dotnet_diagnostic.S1144.severity = none
+
+# CA1051: Do not declare visible instance fields
+# [Params] in BDN are conventionally public fields, not properties.
+# (Our scaffolded benchmark uses { get; set; } so this isn't tripped
+# today, but the carve-out is here for future scenarios that follow
+# the BDN documentation style.)
+dotnet_diagnostic.CA1051.severity = none
+
+# IDE0079: Remove unnecessary suppression
+# Stops cascading suppression-of-suppression noise when individual
+# benchmark files add narrowly-scoped pragmas.
+dotnet_diagnostic.IDE0079.severity = none

--- a/benchmarks/DbContextBuilder.Benchmarks/BenchmarkContext.cs
+++ b/benchmarks/DbContextBuilder.Benchmarks/BenchmarkContext.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolfgang.DbContextBuilderCore.Benchmarks;
+
+/// <summary>
+/// Minimal entity used by the benchmark scenarios. Kept deliberately small
+/// (one scalar property beyond the id) so the per-row cost reflects
+/// DbContextBuilder overhead rather than entity-shape overhead.
+/// </summary>
+public sealed class BenchmarkEntity
+{
+    /// <summary>Primary key.</summary>
+    public int Id { get; set; }
+
+    /// <summary>A representative scalar property.</summary>
+    public string Name { get; set; } = string.Empty;
+}
+
+
+
+/// <summary>
+/// Minimal <see cref="DbContext"/> used by the benchmark scenarios. One
+/// DbSet of <see cref="BenchmarkEntity"/> is enough to exercise the full
+/// build + seed + SaveChanges path without dragging in the cost of a
+/// realistic multi-entity schema.
+/// </summary>
+public sealed class BenchmarkContext(DbContextOptions<BenchmarkContext> options)
+    : DbContext(options)
+{
+    /// <summary>The entity set populated by benchmark seed scenarios.</summary>
+    public DbSet<BenchmarkEntity> Entities => Set<BenchmarkEntity>();
+}

--- a/benchmarks/DbContextBuilder.Benchmarks/BuildAsyncBenchmarks.cs
+++ b/benchmarks/DbContextBuilder.Benchmarks/BuildAsyncBenchmarks.cs
@@ -1,0 +1,95 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Wolfgang.DbContextBuilderCore.Benchmarks;
+
+/// <summary>
+/// Baseline microbenchmarks for <see cref="DbContextBuilder{T}.BuildAsync"/>
+/// across the most common usage shapes. Scenarios:
+///
+/// <list type="bullet">
+///   <item><c>InMemory_NoSeed</c> — empty options, no data seeded.</item>
+///   <item><c>InMemory_SeedWith_N</c> — N pre-built entities seeded via
+///   <see cref="DbContextBuilder{T}.SeedWith{TEntity}(TEntity[])"/>.</item>
+///   <item><c>InMemory_SeedWithRandom_N</c> — N AutoFixture-generated
+///   entities seeded via
+///   <see cref="DbContextBuilder{T}.SeedWithRandom{TEntity}(int)"/>.</item>
+/// </list>
+///
+/// MemoryDiagnoser is on so allocation regressions surface in the gh-pages
+/// benchmark chart immediately.
+///
+/// Each benchmark disposes the constructed <see cref="BenchmarkContext"/>
+/// before returning so successive iterations don't accumulate in-memory
+/// databases or tracked entities that would distort the allocation
+/// measurements.
+/// </summary>
+[MemoryDiagnoser]
+public class BuildAsyncBenchmarks
+{
+    /// <summary>
+    /// Row counts for the seed scenarios. Kept small (1, 10, 100) so the
+    /// chart shows the per-row component of build cost without dominating
+    /// runtime.
+    /// </summary>
+    [Params(1, 10, 100)]
+    public int SeedCount { get; set; }
+
+    private BenchmarkEntity[] _seedRows = [];
+
+    /// <summary>
+    /// Pre-builds the <see cref="BenchmarkEntity"/> array once per
+    /// SeedCount value so the <c>SeedWith</c> benchmark measures only the
+    /// builder cost, not entity construction.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _seedRows = new BenchmarkEntity[SeedCount];
+        for (var i = 0; i < SeedCount; i++)
+        {
+            _seedRows[i] = new BenchmarkEntity { Id = i + 1, Name = $"row-{i + 1}" };
+        }
+    }
+
+
+
+    /// <summary>
+    /// Baseline: builder with default options (InMemory provider), no seed.
+    /// Measures the irreducible cost of <see cref="DbContextBuilder{T}.BuildAsync"/>.
+    /// </summary>
+    [Benchmark(Baseline = true)]
+    public async Task InMemory_NoSeed()
+    {
+        using var builder = new DbContextBuilder<BenchmarkContext>();
+        await using var context = await builder.BuildAsync().ConfigureAwait(false);
+    }
+
+
+
+    /// <summary>
+    /// Builder with <c>SeedCount</c> pre-built entities seeded via
+    /// <see cref="DbContextBuilder{T}.SeedWith{TEntity}(TEntity[])"/>.
+    /// </summary>
+    [Benchmark]
+    public async Task InMemory_SeedWith()
+    {
+        using var builder = new DbContextBuilder<BenchmarkContext>()
+            .SeedWith(_seedRows);
+        await using var context = await builder.BuildAsync().ConfigureAwait(false);
+    }
+
+
+
+    /// <summary>
+    /// Builder with <c>SeedCount</c> AutoFixture-generated entities seeded
+    /// via <see cref="DbContextBuilder{T}.SeedWithRandom{TEntity}(int)"/>.
+    /// Captures the AutoFixture cost on top of the baseline.
+    /// </summary>
+    [Benchmark]
+    public async Task InMemory_SeedWithRandom()
+    {
+        using var builder = new DbContextBuilder<BenchmarkContext>()
+            .SeedWithRandom<BenchmarkEntity>(SeedCount);
+        await using var context = await builder.BuildAsync().ConfigureAwait(false);
+    }
+}

--- a/benchmarks/DbContextBuilder.Benchmarks/DbContextBuilder.Benchmarks.csproj
+++ b/benchmarks/DbContextBuilder.Benchmarks/DbContextBuilder.Benchmarks.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Wolfgang.DbContextBuilderCore.Benchmarks</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.DbContextBuilder-Core\Wolfgang.DbContextBuilder-Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+</Project>

--- a/benchmarks/DbContextBuilder.Benchmarks/Program.cs
+++ b/benchmarks/DbContextBuilder.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);


### PR DESCRIPTION
## Summary

Adds the curated \`benchmarks/.editorconfig\` so the benchmark project
inherits the root \`Directory.Build.props\`'s
\`TreatWarningsAsErrors=true\` (Release) without the BDN-legitimate
analyzer rules tripping the build.

## Carve-outs

| Rule | Why suppressed |
|---|---|
| **CA1822 / S2325** | BDN \`[Benchmark]\` methods must be instance methods so BenchmarkSwitcher can instantiate the class per run. |
| **CA1707** | BDN convention is \`MethodName_VariantName\` so the published chart legend reads naturally. |
| **S1144** | BDN classes / \`[GlobalSetup]\` / \`[Params]\` members are instantiated by reflection; Sonar can't see those usage sites. |
| **CA1051** | \`[Params]\` in BDN docs are typically public fields, not properties. |
| **IDE0079** | Stops suppression-of-suppression cascade noise. |

## Notes

- \`benchmarks/Directory.Build.props\` was never present on this repo,
  so no removal is needed — benchmark code already inherits the root
  DBP's TWEA.
- Verified locally: \`dotnet build benchmarks/DbContextBuilder.Benchmarks -c Release\`
  succeeds with 0 errors **before and after** this editorconfig. The
  carve-outs are preemptive for future scenarios that follow BDN
  convention more aggressively.

## Stacked on

vNext → #249 (P1 baseline) → this PR.