### PR TITLE
D1: close CS1591 XML-doc gaps across all 7 src projects (closes #219)

### DIFF
--- a/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
@@ -21,22 +21,16 @@
 		<PackageIcon>dbcontext-builder.png</PackageIcon>
 		<ApplicationIcon>dbcontext-builder.ico</ApplicationIcon>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<NoWarn>$(NoWarn);1591</NoWarn>
+
 		<SignAssembly>False</SignAssembly>
 		<PackageTags></PackageTags>
-
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsPackable>true</IsPackable>
 		<IsTestProject>false</IsTestProject>
-
 	</PropertyGroup>
-
 	 <PropertyGroup>
 		 <DefineConstants>$(DefineConstants);EF_CORE_10;EF_CORE_10_OR_GREATER</DefineConstants>
 	 </PropertyGroup>
-
-
-
 	 <ItemGroup>
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\AutoFixtureRandomEntityCreator.cs" Link="AutoFixtureRandomEntityCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilder.cs" Link="DbContextBuilder.cs" />
@@ -50,21 +44,17 @@
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteForMsSqlServerModelCustomizer.cs" Link="SqliteForMsSqlServerModelCustomizer.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteModelCustomizer.cs" Link="SqliteModelCustomizer.cs" />
 	 </ItemGroup>
-
-
 	<ItemGroup>
 	  <PackageReference Include="AutoFixture" Version="4.18.1" />
 	  <PackageReference Include="coverlet.collector" Version="10.0.1">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-
 	  <!-- Lock EF to version 10.x but not 11 or later -->
 	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[10.0.5,11.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[10.0.5,11.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[10.0.5,11.0.0)" />
 	</ItemGroup>
-
 	<ItemGroup>
 		<!-- Include the icon and README file directly in the package's root -->
 		<None Include="..\..\README.md" Pack="True" PackagePath="/" />
@@ -76,7 +66,5 @@
                 <Content Include="..\Wolfgang.DbContextBuilder-Core\Content\dbcontext-builder-inverted.png" Link="Content\dbcontext-builder-inverted.png" />
                 <Content Include="dbcontext-builder.ico" Link="Content\dbcontext-builder.ico" />
 	</ItemGroup>
-
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
-
 </Project>

--- a/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
@@ -21,19 +21,16 @@
 		<PackageIcon>dbcontext-builder.png</PackageIcon>
 		<ApplicationIcon>dbcontext-builder.ico</ApplicationIcon>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<NoWarn>$(NoWarn);1591</NoWarn>
+
 		<SignAssembly>False</SignAssembly>
 		<PackageTags></PackageTags>
-
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsPackable>true</IsPackable>
 		<IsTestProject>false</IsTestProject>
 	</PropertyGroup>
-
 	 <PropertyGroup>
 		<DefineConstants>$(DefineConstants);EF_CORE_6;EF_CORE_6_OR_GREATER</DefineConstants>
 	</PropertyGroup>
-
 	 <ItemGroup>
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\AutoFixtureRandomEntityCreator.cs" Link="AutoFixtureRandomEntityCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilder.cs" Link="DbContextBuilder.cs" />
@@ -47,23 +44,17 @@
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteForMsSqlServerModelCustomizer.cs" Link="SqliteForMsSqlServerModelCustomizer.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteModelCustomizer.cs" Link="SqliteModelCustomizer.cs" />
 	 </ItemGroup>
-
-
 	<ItemGroup>
 	  <PackageReference Include="AutoFixture" Version="4.18.1" />
 	  <PackageReference Include="coverlet.collector" Version="10.0.1">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-
-
-
 	  <!-- Lock EF to version 6.x but not 7 or later -->
 	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6.0.36,7.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[6.0.36,7.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[6.0.36,7.0.0)" />
 	</ItemGroup>
-
 	<ItemGroup>
 		<!-- Include the icon and README file directly in the package's root -->
 		<None Include="..\..\README.md" Pack="True" PackagePath="/" />
@@ -75,7 +66,5 @@
                 <Content Include="..\Wolfgang.DbContextBuilder-Core\Content\dbcontext-builder-inverted.png" Link="Content\dbcontext-builder-inverted.png" />
                 <Content Include="dbcontext-builder.ico" Link="Content\dbcontext-builder.ico" />
 	</ItemGroup>
-
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
-
 </Project>

--- a/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
@@ -21,19 +21,16 @@
 		<PackageIcon>dbcontext-builder.png</PackageIcon>
 		<ApplicationIcon>dbcontext-builder.ico</ApplicationIcon>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<NoWarn>$(NoWarn);1591</NoWarn>
+
 		<SignAssembly>False</SignAssembly>
 		<PackageTags></PackageTags>
-
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsPackable>true</IsPackable>
 		<IsTestProject>false</IsTestProject>
 	</PropertyGroup>
-
 	 <PropertyGroup>
 		<DefineConstants>$(DefineConstants);EF_CORE_7;EF_CORE_7_OR_GREATER</DefineConstants>
 	</PropertyGroup>
-
 	 <ItemGroup>
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\AutoFixtureRandomEntityCreator.cs" Link="AutoFixtureRandomEntityCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilder.cs" Link="DbContextBuilder.cs" />
@@ -47,23 +44,17 @@
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteForMsSqlServerModelCustomizer.cs" Link="SqliteForMsSqlServerModelCustomizer.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteModelCustomizer.cs" Link="SqliteModelCustomizer.cs" />
 	 </ItemGroup>
-
-
 	<ItemGroup>
 	  <PackageReference Include="AutoFixture" Version="4.18.1" />
 	  <PackageReference Include="coverlet.collector" Version="10.0.1">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-
-
-
 	  <!-- Lock EF to version 7.x but not 8 or later -->
 	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[7.0.20,8.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[7.0.20,8.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[7.0.20,8.0.0)" />
 	</ItemGroup>
-
 	<ItemGroup>
 		<!-- Include the icon and README file directly in the package's root -->
 		<None Include="..\..\README.md" Pack="True" PackagePath="/" />
@@ -75,7 +66,5 @@
                 <Content Include="..\Wolfgang.DbContextBuilder-Core\Content\dbcontext-builder-inverted.png" Link="Content\dbcontext-builder-inverted.png" />
                 <Content Include="dbcontext-builder.ico" Link="Content\dbcontext-builder.ico" />
 	</ItemGroup>
-
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
-
 </Project>

--- a/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
@@ -21,19 +21,16 @@
 		<PackageIcon>dbcontext-builder.png</PackageIcon>
 		<ApplicationIcon>dbcontext-builder.ico</ApplicationIcon>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<NoWarn>$(NoWarn);1591</NoWarn>
+
 		<SignAssembly>False</SignAssembly>
 		<PackageTags></PackageTags>
-
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsPackable>true</IsPackable>
 		<IsTestProject>false</IsTestProject>
 	</PropertyGroup>
-
 	 <PropertyGroup>
 		 <DefineConstants>$(DefineConstants);EF_CORE_8;EF_CORE_8_OR_GREATER</DefineConstants>
 	 </PropertyGroup>
-
 	 <ItemGroup>
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\AutoFixtureRandomEntityCreator.cs" Link="AutoFixtureRandomEntityCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilder.cs" Link="DbContextBuilder.cs" />
@@ -47,23 +44,17 @@
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteForMsSqlServerModelCustomizer.cs" Link="SqliteForMsSqlServerModelCustomizer.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteModelCustomizer.cs" Link="SqliteModelCustomizer.cs" />
 	 </ItemGroup>
-
-
 	<ItemGroup>
 	  <PackageReference Include="AutoFixture" Version="4.18.1" />
 	  <PackageReference Include="coverlet.collector" Version="10.0.1">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-
-
-
 	  <!-- Lock EF to version 8.x but not 9 or later -->
 	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[8.0.25,9.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[8.0.25,9.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[8.0.25,9.0.0)" />
 	</ItemGroup>
-
 	<ItemGroup>
 		<!-- Include the icon and README file directly in the package's root -->
 		<None Include="..\..\README.md" Pack="True" PackagePath="/" />
@@ -75,7 +66,5 @@
                 <Content Include="..\Wolfgang.DbContextBuilder-Core\Content\dbcontext-builder-inverted.png" Link="Content\dbcontext-builder-inverted.png" />
                 <Content Include="dbcontext-builder.ico" Link="Content\dbcontext-builder.ico" />
 	</ItemGroup>
-
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
-
 </Project>

--- a/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
@@ -21,22 +21,16 @@
 		<PackageIcon>dbcontext-builder.png</PackageIcon>
 		<ApplicationIcon>dbcontext-builder.ico</ApplicationIcon>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<NoWarn>$(NoWarn);1591</NoWarn>
+
 		<SignAssembly>False</SignAssembly>
 		<PackageTags></PackageTags>
-
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsPackable>true</IsPackable>
 		<IsTestProject>false</IsTestProject>
-
 	</PropertyGroup>
-
 	 <PropertyGroup>
 		 <DefineConstants>$(DefineConstants);EF_CORE_9;EF_CORE_9_OR_GREATER</DefineConstants>
 	 </PropertyGroup>
-
-
-
 	 <ItemGroup>
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\AutoFixtureRandomEntityCreator.cs" Link="AutoFixtureRandomEntityCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilder.cs" Link="DbContextBuilder.cs" />
@@ -50,23 +44,17 @@
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteForMsSqlServerModelCustomizer.cs" Link="SqliteForMsSqlServerModelCustomizer.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteModelCustomizer.cs" Link="SqliteModelCustomizer.cs" />
 	 </ItemGroup>
-
-
 	<ItemGroup>
 	  <PackageReference Include="AutoFixture" Version="4.18.1" />
 	  <PackageReference Include="coverlet.collector" Version="10.0.1">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-
-
-
 	  <!-- Lock EF to version 9.x but not 10 or later -->
 	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[9.0.14,10.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[9.0.14,10.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[9.0.14,10.0.0)" />
 	</ItemGroup>
-
 	<ItemGroup>
 		<!-- Include the icon and README file directly in the package's root -->
 		<None Include="..\..\README.md" Pack="True" PackagePath="/" />
@@ -78,7 +66,5 @@
                 <Content Include="..\Wolfgang.DbContextBuilder-Core\Content\dbcontext-builder-inverted.png" Link="Content\dbcontext-builder-inverted.png" />
                 <Content Include="dbcontext-builder.ico" Link="Content\dbcontext-builder.ico" />
 	</ItemGroup>
-
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
-
 </Project>

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderAutoFixtureExtensions.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderAutoFixtureExtensions.cs
@@ -1,7 +1,12 @@
 using Microsoft.EntityFrameworkCore;
 
 namespace Wolfgang.DbContextBuilderCore;
-public static class DbContextBuilderAutoFixtureExtensions 
+
+/// <summary>
+/// Extension methods that wire AutoFixture-backed random entity creation
+/// into <see cref="DbContextBuilder{T}"/>.
+/// </summary>
+public static class DbContextBuilderAutoFixtureExtensions
 {
     /// <summary>
     /// Tell DbContextBuilder to use AutoFixture to create random entities.

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderSqliteExtensions.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderSqliteExtensions.cs
@@ -3,6 +3,12 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Wolfgang.DbContextBuilderCore;
+
+/// <summary>
+/// Extension methods that configure <see cref="DbContextBuilder{T}"/> to
+/// use a SQLite in-memory database (plain SQLite, or SQLite with the
+/// SQL-Server-compatibility customizations).
+/// </summary>
 public static class DbContextBuilderSqliteExtensions
 {
 

--- a/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
@@ -21,17 +21,14 @@
 		<PackageIcon>dbcontext-builder.png</PackageIcon>
 		<ApplicationIcon>Content/dbcontext-builder.ico</ApplicationIcon>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<NoWarn>$(NoWarn);1591</NoWarn>
+
 		<SignAssembly>False</SignAssembly>
 		<PackageTags></PackageTags>
-
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsPackable>true</IsPackable>
 		<IsTestProject>false</IsTestProject>
 		<DefineConstants>$(DefineConstants);EF_CORE_6;EF_CORE_6_OR_GREATER</DefineConstants>
-
 	</PropertyGroup>
-
 	<ItemGroup>
 	  <PackageReference Include="AutoFixture" Version="4.18.1" />
 	  <PackageReference Include="coverlet.collector" Version="10.0.1">
@@ -43,14 +40,11 @@
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[6.0.36,7.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[6.0.36,7.0.0)" />
 	</ItemGroup>
-
 	<ItemGroup>
 		<!-- Include the icon and README file directly in the package's root -->
 		<None Include="..\..\README.md" Pack="True" PackagePath="/" />
 		<None Include="Content\dbcontext-builder.png" Pack="true" PackagePath="/" />
 		<None Include="Content\dbcontext-builder.ico" Pack="true" PackagePath="/" />
 	</ItemGroup>
-
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
-
 </Project>

--- a/src/Wolfgang.DbContextBuilder-EF6/Wolfgang.DbContextBuilder-EF6.csproj
+++ b/src/Wolfgang.DbContextBuilder-EF6/Wolfgang.DbContextBuilder-EF6.csproj
@@ -20,17 +20,15 @@
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<PackageIcon>dbcontext-builder.png</PackageIcon>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<NoWarn>$(NoWarn);1591</NoWarn>
+
 		<SignAssembly>False</SignAssembly>
 		<PackageTags></PackageTags>
 		<IsPackable>true</IsPackable>
 		<IsTestProject>false</IsTestProject>
 	</PropertyGroup>
-
 	<PropertyGroup>
 		<DefineConstants>$(DefineConstants);EF_TRADITIONAL_6</DefineConstants>
 	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="EntityFramework" Version="[6.5.2, 7.0.0)" />
@@ -40,7 +38,6 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 	</ItemGroup>
-
 	<ItemGroup>
 		<None Include="..\..\README.md" Pack="True" PackagePath="/" />
 		<None Include="..\Wolfgang.DbContextBuilder-Core\Content\dbcontext-builder.png">
@@ -50,7 +47,5 @@
 		<Content Include="..\Wolfgang.DbContextBuilder-Core\Content\dbcontext-builder.png" Link="Content\dbcontext-builder.png" />
 		<Content Include="..\Wolfgang.DbContextBuilder-Core\Content\dbcontext-builder-inverted.png" Link="Content\dbcontext-builder-inverted.png" />
 	</ItemGroup>
-
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
-
 </Project>


### PR DESCRIPTION
## Summary

Closes the second half of **#219** — the part the cleanup PR #243
explicitly left open. The first half (consolidating dupe
\`GenerateDocumentationFile\` blocks) already landed in #243.

## What changed

### \`Wolfgang.DbContextBuilder-Core\` — XML docs added
Only **two** missing-doc warnings fired once
\`<NoWarn>\$(NoWarn);1591</NoWarn>\` was removed:

- \`DbContextBuilderAutoFixtureExtensions\` (class)
- \`DbContextBuilderSqliteExtensions\` (class)

Both got a \`<summary>\` explaining their role.

### All 7 src csprojs — NoWarn suppression removed
The \`<NoWarn>\$(NoWarn);1591</NoWarn>\` token is dropped. The src
genuinely meets the bar now: every public member has a \`<summary>\`,
and the suppression is no longer needed to keep the build green.

### Same 6 shim csprojs — PublicAPI nullable annotation fix
Propagates the vNext fix (commit \`6df324d\`) to the six shim variants
(\`Core-EF6/7/8/9/10\`, \`EF6\`). Each carries its own copy of
\`PublicAPI.Shipped.txt\` with the same \`SqliteModelCustomizer\`
property entries that needed \`!\` to satisfy PublicApiAnalyzer 3.3.4's
nullable-annotation matching.

## Verified

\`\`\`
\$ dotnet build src/Wolfgang.DbContextBuilder-Core/...   → 0 errors
\$ dotnet build src/Wolfgang.DbContextBuilder-Core-EF6/...  → 0 errors
\$ dotnet build src/Wolfgang.DbContextBuilder-Core-EF7/...  → 0 errors
\$ dotnet build src/Wolfgang.DbContextBuilder-Core-EF8/...  → 0 errors
\$ dotnet build src/Wolfgang.DbContextBuilder-Core-EF9/...  → 0 errors
\$ dotnet build src/Wolfgang.DbContextBuilder-Core-EF10/... → 0 errors
\$ dotnet build src/Wolfgang.DbContextBuilder-EF6/...       → 0 errors
\`\`\`

## Out of scope

Test projects still have CS1591 gaps (~168 per the body of #235). The
AdventureWorks-generated-models warning debt (\`#235\`) is the separate
follow-up that handles those (re-scaffold with modern \`dotnet ef\` to
emit \`<auto-generated>\` headers, then close test-XML-doc gaps).

Stacked on top of vNext.