### PR TITLE
PublicAPI: add implicit DbContextBuilder<T> parameterless ctor entries

### DIFF
--- a/src/Wolfgang.DbContextBuilder-Core-EF10/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.DbContextBuilder-Core-EF10/PublicAPI.Shipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>
+Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.DbContextBuilder() -> void
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.BuildAsync() -> System.Threading.Tasks.Task<T>
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.Dispose() -> void
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.SeedWith<TEntity>(System.Collections.Generic.IEnumerable<TEntity> entities) -> Wolfgang.DbContextBuilderCore.DbContextBuilder<T>

--- a/src/Wolfgang.DbContextBuilder-Core-EF6/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.DbContextBuilder-Core-EF6/PublicAPI.Shipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>
+Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.DbContextBuilder() -> void
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.BuildAsync() -> System.Threading.Tasks.Task<T>
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.Dispose() -> void
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.SeedWith<TEntity>(System.Collections.Generic.IEnumerable<TEntity> entities) -> Wolfgang.DbContextBuilderCore.DbContextBuilder<T>

--- a/src/Wolfgang.DbContextBuilder-Core-EF7/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.DbContextBuilder-Core-EF7/PublicAPI.Shipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>
+Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.DbContextBuilder() -> void
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.BuildAsync() -> System.Threading.Tasks.Task<T>
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.Dispose() -> void
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.SeedWith<TEntity>(System.Collections.Generic.IEnumerable<TEntity> entities) -> Wolfgang.DbContextBuilderCore.DbContextBuilder<T>

--- a/src/Wolfgang.DbContextBuilder-Core-EF8/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.DbContextBuilder-Core-EF8/PublicAPI.Shipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>
+Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.DbContextBuilder() -> void
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.BuildAsync() -> System.Threading.Tasks.Task<T>
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.Dispose() -> void
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.SeedWith<TEntity>(System.Collections.Generic.IEnumerable<TEntity> entities) -> Wolfgang.DbContextBuilderCore.DbContextBuilder<T>

--- a/src/Wolfgang.DbContextBuilder-Core-EF9/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.DbContextBuilder-Core-EF9/PublicAPI.Shipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>
+Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.DbContextBuilder() -> void
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.BuildAsync() -> System.Threading.Tasks.Task<T>
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.Dispose() -> void
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.SeedWith<TEntity>(System.Collections.Generic.IEnumerable<TEntity> entities) -> Wolfgang.DbContextBuilderCore.DbContextBuilder<T>

--- a/src/Wolfgang.DbContextBuilder-Core/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.DbContextBuilder-Core/PublicAPI.Shipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>
+Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.DbContextBuilder() -> void
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.BuildAsync() -> System.Threading.Tasks.Task<T>
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.Dispose() -> void
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.SeedWith<TEntity>(System.Collections.Generic.IEnumerable<TEntity> entities) -> Wolfgang.DbContextBuilderCore.DbContextBuilder<T>

--- a/src/Wolfgang.DbContextBuilder-EF6/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.DbContextBuilder-EF6/PublicAPI.Shipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 Wolfgang.DbContextBuilderEF6.DbContextBuilder<T>
+Wolfgang.DbContextBuilderEF6.DbContextBuilder<T>.DbContextBuilder() -> void
 Wolfgang.DbContextBuilderEF6.DbContextBuilder<T>.Build() -> T
 Wolfgang.DbContextBuilderEF6.DbContextBuilder<T>.BuildAsync() -> System.Threading.Tasks.Task<T>
 Wolfgang.DbContextBuilderEF6.DbContextBuilder<T>.SeedWith<TEntity>(System.Collections.Generic.IEnumerable<TEntity> entities) -> Wolfgang.DbContextBuilderEF6.DbContextBuilder<T>


### PR DESCRIPTION
## Summary

Each `PublicAPI.Shipped.txt` listed `Wolfgang.X.DbContextBuilder<T>`
as a type but omitted the **implicit public parameterless
constructor** generated by the compiler (the class has no explicit
ctor). PublicApiAnalyzer treats that ctor as part of the shipped
surface and would surface it as RS0016 under stricter analyzer
configurations or future analyzer versions.

Adds the missing entry to all 7 src csprojs:

- 6× Core* shims (`Wolfgang.DbContextBuilder-Core` and the
  EF6/7/8/9/10 variants): `Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.DbContextBuilder() -> void`
- 1× `-EF6` (non-Core, classic EF 6):
  `Wolfgang.DbContextBuilderEF6.DbContextBuilder<T>.DbContextBuilder() -> void`

## Verified

`dotnet build -c Release` succeeds with **0 errors** on every src
csproj.

## Source

7 Copilot review comments on PR #242 (the merged-into-vNext release
PR), one per src csproj — all flagging the same omission. Addressing
in a new stacked PR per the per-repo release flow.