### PR TITLE
Add edge-case tests for OverrideManyToManyTableHandling heuristic (closes #123, #152)

### DIFF
--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteModelCustomizerTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteModelCustomizerTests.cs
@@ -838,7 +838,9 @@ public class SqliteModelCustomizerTests
     /// Verifies the default <see cref="SqliteModelCustomizer.OverrideManyToManyTableHandling"/>
     /// behaviour on a self-referencing many-to-many join: an Employee.Subordinates collection
     /// produces a join entity whose two foreign keys both point back to Employee. The heuristic
-    /// matches (2 FKs, 0 navigations) and produces a deterministic name of <c>Employee_Employee</c>.
+    /// matches (2 FKs, 0 navigations) and produces a deterministic name. The heuristic uses
+    /// the configured principal table name (<c>"Employees"</c> via <c>ToTable</c>), so the
+    /// expected rename is <c>Employees_Employees</c>.
     /// This pins the behaviour so future refactors don't silently change the self-reference name.
     /// </summary>
     [Fact]
@@ -884,9 +886,11 @@ public class SqliteModelCustomizerTests
         // Act
         sut.OverrideManyToManyTableHandling(entity);
 
-        // Assert — both FK principals are Employee, so the rename produces Employee_Employee.
-        // Consumers who want a more descriptive name (Employee_Subordinate, EmployeeHierarchy,
-        // etc.) should assign a custom OverrideManyToManyTableHandling delegate.
+        // Assert — both FK principals resolve to the same configured table name
+        // ("Employees" via ToTable), so the heuristic's "{Left}_{Right}" join produces
+        // "Employees_Employees". Consumers who want a more descriptive name
+        // (Employee_Subordinate, EmployeeHierarchy, etc.) should assign a custom
+        // OverrideManyToManyTableHandling delegate.
         Assert.Equal("Employees_Employees", entity.GetTableName());
     }
 

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteModelCustomizerTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteModelCustomizerTests.cs
@@ -698,4 +698,256 @@ public class SqliteModelCustomizerTests
         sut.DefaultValueMap["(my_runtime_added())"] = "1";
         Assert.Equal("1", sut.OverrideDefaultValueHandling("(my_runtime_added())"));
     }
+
+
+
+    /// <summary>
+    /// Verifies that the default <see cref="SqliteModelCustomizer.OverrideManyToManyTableHandling"/>
+    /// implementation does NOT rename an entity with 3 foreign keys. The heuristic targets pure
+    /// many-to-many join tables (exactly 2 FKs, 0 navigations); entities with additional FKs
+    /// represent richer relationships (e.g. an OrderItem that joins Order, Product, AND Warehouse)
+    /// and must keep their declared table name.
+    /// </summary>
+    [Fact]
+    public void OverrideManyToManyTableHandling_default_implementation_does_not_rename_entity_with_three_foreign_keys()
+    {
+        // Arrange
+#if EF_CORE_6
+        var finder = new Mock<IDbSetFinder>().Object;
+        var dependencies = new ModelCustomizerDependencies(finder);
+#else
+        var dependencies = new ModelCustomizerDependencies();
+#endif
+
+        var sut = new SqliteModelCustomizer(dependencies);
+
+        var modelBuilder = new ModelBuilder();
+
+        modelBuilder.Entity("Order", b =>
+        {
+            b.Property<int>("Id");
+            b.HasKey("Id");
+            b.ToTable("Orders");
+        });
+
+        modelBuilder.Entity("Product", b =>
+        {
+            b.Property<int>("Id");
+            b.HasKey("Id");
+            b.ToTable("Products");
+        });
+
+        modelBuilder.Entity("Warehouse", b =>
+        {
+            b.Property<int>("Id");
+            b.HasKey("Id");
+            b.ToTable("Warehouses");
+        });
+
+        modelBuilder.Entity("OrderItem", b =>
+        {
+            b.Property<int>("OrderId");
+            b.Property<int>("ProductId");
+            b.Property<int>("WarehouseId");
+            b.HasKey("OrderId", "ProductId", "WarehouseId");
+            b.ToTable("OrderItems");
+            b.HasOne("Order").WithMany().HasForeignKey("OrderId");
+            b.HasOne("Product").WithMany().HasForeignKey("ProductId");
+            b.HasOne("Warehouse").WithMany().HasForeignKey("WarehouseId");
+        });
+
+        var entity = modelBuilder.Model.FindEntityType("OrderItem")!;
+
+        // Precondition — 3 FKs
+        Assert.Equal(3, entity.GetForeignKeys().Count());
+
+        // Act
+        sut.OverrideManyToManyTableHandling(entity);
+
+        // Assert — table name unchanged
+        Assert.Equal("OrderItems", entity.GetTableName());
+    }
+
+
+
+    /// <summary>
+    /// Verifies that the default <see cref="SqliteModelCustomizer.OverrideManyToManyTableHandling"/>
+    /// implementation does NOT rename an entity that has exactly 2 foreign keys but also has at
+    /// least one navigation property. Navigations indicate EF treats the entity as first-class
+    /// (not a pure many-to-many join), so its declared table name must be preserved.
+    /// </summary>
+    [Fact]
+    public void OverrideManyToManyTableHandling_default_implementation_does_not_rename_entity_with_navigations()
+    {
+        // Arrange
+#if EF_CORE_6
+        var finder = new Mock<IDbSetFinder>().Object;
+        var dependencies = new ModelCustomizerDependencies(finder);
+#else
+        var dependencies = new ModelCustomizerDependencies();
+#endif
+
+        var sut = new SqliteModelCustomizer(dependencies);
+
+        var modelBuilder = new ModelBuilder();
+
+        modelBuilder.Entity("Author", b =>
+        {
+            b.Property<int>("Id");
+            b.HasKey("Id");
+            b.ToTable("Authors");
+        });
+
+        modelBuilder.Entity("Book", b =>
+        {
+            b.Property<int>("Id");
+            b.HasKey("Id");
+            b.ToTable("Books");
+        });
+
+        // Authorship is conceptually a join (2 FKs to Author + Book) but also models
+        // first-class data (e.g. a Role string). EF surfaces it with navigations on
+        // both sides; the heuristic must not flatten its table name.
+        modelBuilder.Entity("Authorship", b =>
+        {
+            b.Property<int>("AuthorId");
+            b.Property<int>("BookId");
+            b.Property<string>("Role");
+            b.HasKey("AuthorId", "BookId");
+            b.ToTable("Authorships");
+            b.HasOne("Author", "Author").WithMany().HasForeignKey("AuthorId");
+            b.HasOne("Book", "Book").WithMany().HasForeignKey("BookId");
+        });
+
+        var entity = modelBuilder.Model.FindEntityType("Authorship")!;
+
+        // Precondition — exactly 2 FKs but navigations present
+        Assert.Equal(2, entity.GetForeignKeys().Count());
+        Assert.NotEmpty(entity.GetNavigations());
+
+        // Act
+        sut.OverrideManyToManyTableHandling(entity);
+
+        // Assert — table name unchanged
+        Assert.Equal("Authorships", entity.GetTableName());
+    }
+
+
+
+    /// <summary>
+    /// Verifies the default <see cref="SqliteModelCustomizer.OverrideManyToManyTableHandling"/>
+    /// behaviour on a self-referencing many-to-many join: an Employee.Subordinates collection
+    /// produces a join entity whose two foreign keys both point back to Employee. The heuristic
+    /// matches (2 FKs, 0 navigations) and produces a deterministic name of <c>Employee_Employee</c>.
+    /// This pins the behaviour so future refactors don't silently change the self-reference name.
+    /// </summary>
+    [Fact]
+    public void OverrideManyToManyTableHandling_default_implementation_handles_self_referencing_join()
+    {
+        // Arrange
+#if EF_CORE_6
+        var finder = new Mock<IDbSetFinder>().Object;
+        var dependencies = new ModelCustomizerDependencies(finder);
+#else
+        var dependencies = new ModelCustomizerDependencies();
+#endif
+
+        var sut = new SqliteModelCustomizer(dependencies);
+
+        var modelBuilder = new ModelBuilder();
+
+        modelBuilder.Entity("Employee", b =>
+        {
+            b.Property<int>("Id");
+            b.HasKey("Id");
+            b.ToTable("Employees");
+        });
+
+        // Self-referencing join: both FKs point to Employee. EF generates this for
+        // an Employee.Subordinates many-to-many relationship.
+        modelBuilder.Entity("EmployeeSubordinate", b =>
+        {
+            b.Property<int>("ManagerId");
+            b.Property<int>("SubordinateId");
+            b.HasKey("ManagerId", "SubordinateId");
+            b.ToTable("EmployeeSubordinates");
+            b.HasOne("Employee").WithMany().HasForeignKey("ManagerId");
+            b.HasOne("Employee").WithMany().HasForeignKey("SubordinateId");
+        });
+
+        var entity = modelBuilder.Model.FindEntityType("EmployeeSubordinate")!;
+
+        // Precondition — heuristic should match: 2 FKs, 0 navigations
+        Assert.Equal(2, entity.GetForeignKeys().Count());
+        Assert.Empty(entity.GetNavigations());
+
+        // Act
+        sut.OverrideManyToManyTableHandling(entity);
+
+        // Assert — both FK principals are Employee, so the rename produces Employee_Employee.
+        // Consumers who want a more descriptive name (Employee_Subordinate, EmployeeHierarchy,
+        // etc.) should assign a custom OverrideManyToManyTableHandling delegate.
+        Assert.Equal("Employees_Employees", entity.GetTableName());
+    }
+
+
+
+    /// <summary>
+    /// Documents the happy path explicitly under the "exactly 2 FKs, 0 navigations" precondition
+    /// using the new XML doc convention (the original
+    /// <c>OverrideManyToManyTableHandling_default_implementation_renames_join_table</c> test
+    /// covers the same scenario; this duplication is intentional for documentation value and
+    /// will survive any rename of the original).
+    /// </summary>
+    [Fact]
+    public void OverrideManyToManyTableHandling_default_implementation_renames_pure_join_with_two_fks_and_no_navigations()
+    {
+        // Arrange
+#if EF_CORE_6
+        var finder = new Mock<IDbSetFinder>().Object;
+        var dependencies = new ModelCustomizerDependencies(finder);
+#else
+        var dependencies = new ModelCustomizerDependencies();
+#endif
+
+        var sut = new SqliteModelCustomizer(dependencies);
+
+        var modelBuilder = new ModelBuilder();
+
+        modelBuilder.Entity("Tag", b =>
+        {
+            b.Property<int>("Id");
+            b.HasKey("Id");
+            b.ToTable("Tags");
+        });
+
+        modelBuilder.Entity("Post", b =>
+        {
+            b.Property<int>("Id");
+            b.HasKey("Id");
+            b.ToTable("Posts");
+        });
+
+        modelBuilder.Entity("PostTag", b =>
+        {
+            b.Property<int>("PostId");
+            b.Property<int>("TagId");
+            b.HasKey("PostId", "TagId");
+            b.ToTable("PostTags");
+            b.HasOne("Post").WithMany().HasForeignKey("PostId");
+            b.HasOne("Tag").WithMany().HasForeignKey("TagId");
+        });
+
+        var entity = modelBuilder.Model.FindEntityType("PostTag")!;
+
+        // Precondition — heuristic match
+        Assert.Equal(2, entity.GetForeignKeys().Count());
+        Assert.Empty(entity.GetNavigations());
+
+        // Act
+        sut.OverrideManyToManyTableHandling(entity);
+
+        // Assert — renamed to {LeftPrincipalTable}_{RightPrincipalTable}
+        Assert.Equal("Posts_Tags", entity.GetTableName());
+    }
 }


### PR DESCRIPTION
## Summary

Adds **4 edge-case tests** to pin the boundary behaviour of the default
`OverrideManyToManyTableHandling` heuristic on `SqliteModelCustomizer`.

The override-delegate machinery and one happy-path test already shipped
in v0.6.2. The remaining `#123` acceptance criterion called for
*"tests for edge cases in the current heuristic (e.g., self-referencing
many-to-many)"* — this PR closes that out without changing the
heuristic itself.

## Tests added

| Test | Pins |
|---|---|
| `does_not_rename_entity_with_three_foreign_keys` | 3-FK entity (`OrderItem` → Order/Product/Warehouse) must keep its declared table name. |
| `does_not_rename_entity_with_navigations` | 2-FK entity with navigation properties (`Authorship` with Author/Book + Role) is first-class EF data, not a pure join — name preserved. |
| `handles_self_referencing_join` | Canonical `Employee.Subordinates` case: both FKs to Employee → renames to `Employees_Employees`. Consumers needing a more descriptive name should supply a custom delegate. |
| `renames_pure_join_with_two_fks_and_no_navigations` | Happy path restated under new naming convention (PostTag → Posts_Tags). Duplicates existing test for documentation value. |

## Verified

- `dotnet build -c Release` — 0 errors, only pre-existing CA1062
  warnings on AdventureWorks generated models (#235 territory).
- `dotnet test --filter "FullyQualifiedName~OverrideManyToManyTableHandling"`:
  **7 tests passed** (3 original + 4 new).

## Out of scope

No changes to `SqliteModelCustomizer.cs` itself. No new public API.
Only test additions.

Closes #123, #152 (duplicates of each other).