### PR TITLE
Add end-to-end schema-qualified table round-trip tests (closes #148, #119)

### DIFF
--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/TestsWithSqliteAndAutoFixture.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/TestsWithSqliteAndAutoFixture.cs
@@ -544,7 +544,7 @@ public class TestsWithSqliteAndAutoFixture : DbContextBuilderTestsBase
     public async Task BuildAsync_via_SqliteForMsSqlServer_does_not_emit_schema_configured_warning()
     {
         // Arrange — capture all EF log output via .LogTo
-        var sut = CreateDbContextBuilder();
+        using var sut = CreateDbContextBuilder();
 
         var buffer = new StringBuilder(10_240);
         var sw = new StringWriter(buffer);

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/TestsWithSqliteAndAutoFixture.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/TestsWithSqliteAndAutoFixture.cs
@@ -434,4 +434,135 @@ public class TestsWithSqliteAndAutoFixture : DbContextBuilderTestsBase
         // Assert
         Assert.NotNull(context);
     }
+
+
+
+    /// <summary>
+    /// Round-trips a single entity from a non-default SQL Server schema (Person.BusinessEntity)
+    /// through the SQLite provider. Confirms that the OverrideTableRenaming flattening
+    /// (Person.BusinessEntity → Person_BusinessEntity) does not break the EF entity surface
+    /// for either write (SeedWith → SaveChanges via BuildAsync) or read (subsequent query
+    /// against the returned context).
+    /// </summary>
+    [Fact]
+    public async Task BuildAsync_via_SqliteForMsSqlServer_round_trips_entity_from_non_default_schema()
+    {
+        // Arrange — BusinessEntity is mapped to Person.BusinessEntity in AdventureWorksDbContext
+        // (see entity.ToTable("BusinessEntity", "Person") in OnModelCreating). It has a simple
+        // shape (int Id, Guid Rowguid, DateTime ModifiedDate) with no required FKs, so seeding
+        // it standalone doesn't need a dependency tree.
+        var seedRowguid = Guid.NewGuid();
+        var seedModifiedDate = new DateTime(2026, 5, 31, 12, 0, 0, DateTimeKind.Utc);
+        var seed = new BusinessEntity
+        {
+            BusinessEntityId = 42,
+            Rowguid = seedRowguid,
+            ModifiedDate = seedModifiedDate,
+        };
+
+        using var sut = CreateDbContextBuilder().SeedWith(seed);
+
+        // Act
+        await using var context = await sut.BuildAsync();
+        var roundTripped = await context.BusinessEntities.FindAsync(42);
+
+        // Assert
+        Assert.NotNull(roundTripped);
+        Assert.Equal(42, roundTripped!.BusinessEntityId);
+        Assert.Equal(seedRowguid, roundTripped.Rowguid);
+        Assert.Equal(seedModifiedDate, roundTripped.ModifiedDate);
+    }
+
+
+
+    /// <summary>
+    /// Seeds one entity from each of three distinct SQL Server schemas
+    /// (Person.BusinessEntity, Sales.Currency, Production.Culture) in a single BuildAsync
+    /// call and verifies all three round-trip cleanly. Pins that the schema-name flattening
+    /// collapses across multiple source schemas without producing SQLite table-name
+    /// collisions.
+    ///
+    /// Each entity is deliberately chosen as a FK-free root in the AdventureWorks model
+    /// so the seed plan doesn't need a dependency tree (CountryRegionCurrency, also in
+    /// the Sales schema, has FK constraints to CountryRegion and Currency and would not
+    /// satisfy SQLite's foreign-key checks without those parents).
+    /// </summary>
+    [Fact]
+    public async Task BuildAsync_via_SqliteForMsSqlServer_round_trips_entities_from_multiple_schemas()
+    {
+        // Arrange — one entity per schema, all FK-free roots
+        var businessEntity = new BusinessEntity
+        {
+            BusinessEntityId = 1,
+            Rowguid = Guid.NewGuid(),
+            ModifiedDate = new DateTime(2026, 5, 31, 12, 0, 0, DateTimeKind.Utc),
+        };
+
+        var currency = new Currency
+        {
+            CurrencyCode = "USD",
+            Name = "US Dollar",
+            ModifiedDate = new DateTime(2026, 5, 31, 12, 0, 0, DateTimeKind.Utc),
+        };
+
+        var culture = new Culture
+        {
+            CultureId = "en",
+            Name = "English",
+            ModifiedDate = new DateTime(2026, 5, 31, 12, 0, 0, DateTimeKind.Utc),
+        };
+
+        using var sut = CreateDbContextBuilder()
+            .SeedWith<BusinessEntity>(businessEntity)
+            .SeedWith<Currency>(currency)
+            .SeedWith<Culture>(culture);
+
+        // Act
+        await using var context = await sut.BuildAsync();
+
+        var persons = await context.BusinessEntities.CountAsync();
+        var sales = await context.Currencies.CountAsync();
+        var production = await context.Cultures.CountAsync();
+
+        // Assert — each schema's table holds exactly the row we seeded into it
+        Assert.Equal(1, persons);
+        Assert.Equal(1, sales);
+        Assert.Equal(1, production);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that BuildAsync with the SqliteForMsSqlServer customizer does NOT emit the
+    /// EF Core "schema configured but provider does not support schemas" warning. The
+    /// OverrideTableRenaming default flattens schemas to single underscore-prefixed names
+    /// (Person.Address → Person_Address) before EF's model-builder sees them, which should
+    /// prevent the warning from firing. If a future change re-introduces the warning, this
+    /// test surfaces it via the captured log buffer.
+    /// </summary>
+    [Fact]
+    public async Task BuildAsync_via_SqliteForMsSqlServer_does_not_emit_schema_configured_warning()
+    {
+        // Arrange — capture all EF log output via .LogTo
+        var sut = CreateDbContextBuilder();
+
+        var buffer = new StringBuilder(10_240);
+        var sw = new StringWriter(buffer);
+
+        var optionsBuilder = new DbContextOptionsBuilder<AdventureWorksDbContext>()
+            .LogTo(s => sw.WriteLine(s));
+
+        sut.UseDbContextOptionsBuilder(optionsBuilder);
+
+        // Act
+        await using var context = await sut.BuildAsync();
+        var log = buffer.ToString();
+
+        // Assert — no schema-warning text in the log. Two complementary text checks
+        // because EF Core has surfaced the warning under slightly different message
+        // shapes across versions ("schema 'X' but provider does not support" vs
+        // "SchemaConfiguredWarning"). Either substring would indicate the warning fired.
+        Assert.DoesNotContain("SchemaConfigured", log, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("does not support schemas", log, StringComparison.OrdinalIgnoreCase);
+    }
 }


### PR DESCRIPTION
## Summary

Adds **3 end-to-end tests** that exercise the SQL-Server-schema-to-
SQLite-flat-table mapping (e.g. `Person.BusinessEntity` →
`Person_BusinessEntity`) for read+write through the EF entity surface.

The renaming mechanism already shipped in v0.6.2 (via
`SqliteForMsSqlServerModelCustomizer.OverrideTableRenaming`), and one
existing test asserts the `CREATE TABLE "Person_Person"` SQL gets
emitted. What was missing — and is the substance of both #148 and
#119 — is an actual CRUD round-trip verifying the renamed tables
function end-to-end.

## Tests added

| Test | Verifies |
|---|---|
| `round_trips_entity_from_non_default_schema` | Single `BusinessEntity` (Person schema) seeds, builds, queries, and every scalar prop round-trips intact. |
| `round_trips_entities_from_multiple_schemas` | One FK-free root from each of three schemas (Person.BusinessEntity, Sales.Currency, Production.Culture) all round-trip in a single BuildAsync. Proves no SQLite name collisions when multiple schemas flatten. |
| `does_not_emit_schema_configured_warning` | Captures EF logs via `.LogTo(...)` and asserts no `SchemaConfigured` warning text leaks through — the rename happens before EF sees the schema, so the warning shouldn't fire. |

## Notes

- `CountryRegionCurrency` was the obvious Sales-schema candidate but
  has FK constraints to `CountryRegion` + `Currency` that would fail
  SQLite's FK check without seeding parents. The test uses
  `Currency` (a parent/lookup with no outgoing FKs) instead, and
  documents the choice inline.
- The "no schema warning" test uses two complementary text checks
  (`"SchemaConfigured"` and `"does not support schemas"`) because EF
  Core has surfaced the warning under slightly different message
  shapes across versions. Either would indicate the warning fired.

## Verified

- `dotnet build -c Release` — 0 errors.
- `dotnet test --filter "FullyQualifiedName~BuildAsync_via_SqliteForMsSqlServer"`:
  **3 new tests passed** (plus existing SqliteForMsSqlServer tests
  in the same suite all still green).

## Out of scope

No changes to library code. No new public API. Test-only.

Closes #148, #119 (paired feature + tests).