### PR TITLE
Rewire EF8/9/10 tests to use their matching AdventureWorks scaffold (closes #41, #42, #43)

### DIFF
--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Address.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Address.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Street address information for customers, employees, and vendors.
 /// </summary>
-public partial class Address
-{
+public partial record Address{
     /// <summary>
     /// Primary key for Address records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/AddressType.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/AddressType.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Types of addresses stored in the Address table. 
 /// </summary>
-public partial class AddressType
-{
+public partial record AddressType{
     /// <summary>
     /// Primary key for AddressType records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/AdventureWorksDbContext.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/AdventureWorksDbContext.cs
@@ -790,7 +790,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("Employee", "HumanResources", tb =>
                 {
                     tb.HasComment("Employee information such as salary, department, and title.");
-                    tb.HasTrigger("dEmployee");
                 });
 
             entity.HasIndex(e => e.LoginId, "AK_Employee_LoginID").IsUnique();
@@ -1059,7 +1058,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("Person", "Person", tb =>
                 {
                     tb.HasComment("Human beings involved with AdventureWorks: employees, customer contacts, and vendor contacts.");
-                    tb.HasTrigger("iuPerson");
                 });
 
             entity.HasIndex(e => e.Rowguid, "AK_Person_rowguid").IsUnique();
@@ -1727,8 +1725,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("PurchaseOrderDetail", "Purchasing", tb =>
                 {
                     tb.HasComment("Individual products associated with a specific purchase order. See PurchaseOrderHeader.");
-                    tb.HasTrigger("iPurchaseOrderDetail");
-                    tb.HasTrigger("uPurchaseOrderDetail");
                 });
 
             entity.HasIndex(e => e.ProductId, "IX_PurchaseOrderDetail_ProductID");
@@ -1785,7 +1781,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("PurchaseOrderHeader", "Purchasing", tb =>
                 {
                     tb.HasComment("General purchase order information. See PurchaseOrderDetail.");
-                    tb.HasTrigger("uPurchaseOrderHeader");
                 });
 
             entity.HasIndex(e => e.EmployeeId, "IX_PurchaseOrderHeader_EmployeeID");
@@ -1853,7 +1848,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("SalesOrderDetail", "Sales", tb =>
                 {
                     tb.HasComment("Individual products associated with a specific sales order. See SalesOrderHeader.");
-                    tb.HasTrigger("iduSalesOrderDetail");
                 });
 
             entity.HasIndex(e => e.Rowguid, "AK_SalesOrderDetail_rowguid").IsUnique();
@@ -1911,7 +1905,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("SalesOrderHeader", "Sales", tb =>
                 {
                     tb.HasComment("General sales order information.");
-                    tb.HasTrigger("uSalesOrderHeader");
                 });
 
             entity.HasIndex(e => e.SalesOrderNumber, "AK_SalesOrderHeader_SalesOrderNumber").IsUnique();
@@ -3305,7 +3298,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("Vendor", "Purchasing", tb =>
                 {
                     tb.HasComment("Companies from whom Adventure Works Cycles purchases parts or other goods.");
-                    tb.HasTrigger("dVendor");
                 });
 
             entity.HasIndex(e => e.AccountNumber, "AK_Vendor_AccountNumber").IsUnique();
@@ -3350,8 +3342,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("WorkOrder", "Production", tb =>
                 {
                     tb.HasComment("Manufacturing work orders.");
-                    tb.HasTrigger("iWorkOrder");
-                    tb.HasTrigger("uWorkOrder");
                 });
 
             entity.HasIndex(e => e.ProductId, "IX_WorkOrder_ProductID");

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/AwbuildVersion.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/AwbuildVersion.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Current version number of the AdventureWorks 2016 sample database. 
 /// </summary>
-public partial class AwbuildVersion
-{
+public partial record AwbuildVersion{
     /// <summary>
     /// Primary key for AWBuildVersion records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/BillOfMaterial.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/BillOfMaterial.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Items required to make bicycles and bicycle subassemblies. It identifies the heirarchical relationship between a parent product and its components.
 /// </summary>
-public partial class BillOfMaterial
-{
+public partial record BillOfMaterial{
     /// <summary>
     /// Primary key for BillOfMaterials records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/BusinessEntity.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/BusinessEntity.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Source of the ID that connects vendors, customers, and employees with address and contact information.
 /// </summary>
-public partial class BusinessEntity
-{
+public partial record BusinessEntity{
     /// <summary>
     /// Primary key for all customers, vendors, and employees.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/BusinessEntityAddress.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/BusinessEntityAddress.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping customers, vendors, and employees to their addresses.
 /// </summary>
-public partial class BusinessEntityAddress
-{
+public partial record BusinessEntityAddress{
     /// <summary>
     /// Primary key. Foreign key to BusinessEntity.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/BusinessEntityContact.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/BusinessEntityContact.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping stores, vendors, and employees to people
 /// </summary>
-public partial class BusinessEntityContact
-{
+public partial record BusinessEntityContact{
     /// <summary>
     /// Primary key. Foreign key to BusinessEntity.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ContactType.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ContactType.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table containing the types of business entity contacts.
 /// </summary>
-public partial class ContactType
-{
+public partial record ContactType{
     /// <summary>
     /// Primary key for ContactType records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/CountryRegion.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/CountryRegion.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table containing the ISO standard codes for countries and regions.
 /// </summary>
-public partial class CountryRegion
-{
+public partial record CountryRegion{
     /// <summary>
     /// ISO standard code for countries and regions.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/CountryRegionCurrency.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/CountryRegionCurrency.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping ISO currency codes to a country or region.
 /// </summary>
-public partial class CountryRegionCurrency
-{
+public partial record CountryRegionCurrency{
     /// <summary>
     /// ISO code for countries and regions. Foreign key to CountryRegion.CountryRegionCode.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/CreditCard.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/CreditCard.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Customer credit card information.
 /// </summary>
-public partial class CreditCard
-{
+public partial record CreditCard{
     /// <summary>
     /// Primary key for CreditCard records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Culture.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Culture.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table containing the languages in which some AdventureWorks data is stored.
 /// </summary>
-public partial class Culture
-{
+public partial record Culture{
     /// <summary>
     /// Primary key for Culture records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Currency.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Currency.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table containing standard ISO currencies.
 /// </summary>
-public partial class Currency
-{
+public partial record Currency{
     /// <summary>
     /// The ISO code for the Currency.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/CurrencyRate.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/CurrencyRate.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Currency exchange rates.
 /// </summary>
-public partial class CurrencyRate
-{
+public partial record CurrencyRate{
     /// <summary>
     /// Primary key for CurrencyRate records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Customer.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Customer.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Current customer information. Also see the Person and Store tables.
 /// </summary>
-public partial class Customer
-{
+public partial record Customer{
     /// <summary>
     /// Primary key.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/DatabaseLog.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/DatabaseLog.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Audit table tracking all DDL changes made to the AdventureWorks database. Data is captured by the database trigger ddlDatabaseTriggerLog.
 /// </summary>
-public partial class DatabaseLog
-{
+public partial record DatabaseLog{
     /// <summary>
     /// Primary key for DatabaseLog records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Department.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Department.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table containing the departments within the Adventure Works Cycles company.
 /// </summary>
-public partial class Department
-{
+public partial record Department{
     /// <summary>
     /// Primary key for Department records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/EmailAddress.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/EmailAddress.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Where to send a person email.
 /// </summary>
-public partial class EmailAddress
-{
+public partial record EmailAddress{
     /// <summary>
     /// Primary key. Person associated with this email address.  Foreign key to Person.BusinessEntityID
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Employee.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Employee.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Employee information such as salary, department, and title.
 /// </summary>
-public partial class Employee
-{
+public partial record Employee{
     /// <summary>
     /// Primary key for Employee records.  Foreign key to BusinessEntity.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/EmployeeDepartmentHistory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/EmployeeDepartmentHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Employee department transfers.
 /// </summary>
-public partial class EmployeeDepartmentHistory
-{
+public partial record EmployeeDepartmentHistory{
     /// <summary>
     /// Employee identification number. Foreign key to Employee.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/EmployeePayHistory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/EmployeePayHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Employee pay history.
 /// </summary>
-public partial class EmployeePayHistory
-{
+public partial record EmployeePayHistory{
     /// <summary>
     /// Employee identification number. Foreign key to Employee.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ErrorLog.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ErrorLog.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Audit table tracking errors in the the AdventureWorks database that are caught by the CATCH block of a TRY...CATCH construct. Data is inserted by stored procedure dbo.uspLogError when it is executed from inside the CATCH block of a TRY...CATCH construct.
 /// </summary>
-public partial class ErrorLog
-{
+public partial record ErrorLog{
     /// <summary>
     /// Primary key for ErrorLog records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Illustration.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Illustration.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Bicycle assembly diagrams.
 /// </summary>
-public partial class Illustration
-{
+public partial record Illustration{
     /// <summary>
     /// Primary key for Illustration records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/JobCandidate.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/JobCandidate.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Résumés submitted to Human Resources by job applicants.
 /// </summary>
-public partial class JobCandidate
-{
+public partial record JobCandidate{
     /// <summary>
     /// Primary key for JobCandidate records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Location.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Location.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product inventory and manufacturing locations.
 /// </summary>
-public partial class Location
-{
+public partial record Location{
     /// <summary>
     /// Primary key for Location records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Password.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Password.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// One way hashed authentication information
 /// </summary>
-public partial class Password
-{
+public partial record Password{
     public int BusinessEntityId { get; set; }
 
     /// <summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Person.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Person.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Human beings involved with AdventureWorks: employees, customer contacts, and vendor contacts.
 /// </summary>
-public partial class Person
-{
+public partial record Person{
     /// <summary>
     /// Primary key for Person records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/PersonCreditCard.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/PersonCreditCard.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping people to their credit card information in the CreditCard table. 
 /// </summary>
-public partial class PersonCreditCard
-{
+public partial record PersonCreditCard{
     /// <summary>
     /// Business entity identification number. Foreign key to Person.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/PersonPhone.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/PersonPhone.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Telephone number and type of a person.
 /// </summary>
-public partial class PersonPhone
-{
+public partial record PersonPhone{
     /// <summary>
     /// Business entity identification number. Foreign key to Person.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/PhoneNumberType.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/PhoneNumberType.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Type of phone number of a person.
 /// </summary>
-public partial class PhoneNumberType
-{
+public partial record PhoneNumberType{
     /// <summary>
     /// Primary key for telephone number type records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Product.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Product.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Products sold or used in the manfacturing of sold products.
 /// </summary>
-public partial class Product
-{
+public partial record Product{
     /// <summary>
     /// Primary key for Product records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductCategory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductCategory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// High-level product categorization.
 /// </summary>
-public partial class ProductCategory
-{
+public partial record ProductCategory{
     /// <summary>
     /// Primary key for ProductCategory records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductCostHistory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductCostHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Changes in the cost of a product over time.
 /// </summary>
-public partial class ProductCostHistory
-{
+public partial record ProductCostHistory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductDescription.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductDescription.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product descriptions in several languages.
 /// </summary>
-public partial class ProductDescription
-{
+public partial record ProductDescription{
     /// <summary>
     /// Primary key for ProductDescription records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductInventory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductInventory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product inventory information.
 /// </summary>
-public partial class ProductInventory
-{
+public partial record ProductInventory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductListPriceHistory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductListPriceHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Changes in the list price of a product over time.
 /// </summary>
-public partial class ProductListPriceHistory
-{
+public partial record ProductListPriceHistory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductModel.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductModel.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product model classification.
 /// </summary>
-public partial class ProductModel
-{
+public partial record ProductModel{
     /// <summary>
     /// Primary key for ProductModel records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductModelIllustration.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductModelIllustration.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping product models and illustrations.
 /// </summary>
-public partial class ProductModelIllustration
-{
+public partial record ProductModelIllustration{
     /// <summary>
     /// Primary key. Foreign key to ProductModel.ProductModelID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductModelProductDescriptionCulture.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductModelProductDescriptionCulture.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping product descriptions and the language the description is written in.
 /// </summary>
-public partial class ProductModelProductDescriptionCulture
-{
+public partial record ProductModelProductDescriptionCulture{
     /// <summary>
     /// Primary key. Foreign key to ProductModel.ProductModelID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductPhoto.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductPhoto.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product images.
 /// </summary>
-public partial class ProductPhoto
-{
+public partial record ProductPhoto{
     /// <summary>
     /// Primary key for ProductPhoto records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductProductPhoto.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductProductPhoto.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping products and product photos.
 /// </summary>
-public partial class ProductProductPhoto
-{
+public partial record ProductProductPhoto{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductReview.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductReview.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Customer reviews of products they have purchased.
 /// </summary>
-public partial class ProductReview
-{
+public partial record ProductReview{
     /// <summary>
     /// Primary key for ProductReview records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductSubcategory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductSubcategory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product subcategories. See ProductCategory table.
 /// </summary>
-public partial class ProductSubcategory
-{
+public partial record ProductSubcategory{
     /// <summary>
     /// Primary key for ProductSubcategory records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductVendor.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductVendor.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping vendors with the products they supply.
 /// </summary>
-public partial class ProductVendor
-{
+public partial record ProductVendor{
     /// <summary>
     /// Primary key. Foreign key to Product.ProductID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/PurchaseOrderDetail.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/PurchaseOrderDetail.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Individual products associated with a specific purchase order. See PurchaseOrderHeader.
 /// </summary>
-public partial class PurchaseOrderDetail
-{
+public partial record PurchaseOrderDetail{
     /// <summary>
     /// Primary key. Foreign key to PurchaseOrderHeader.PurchaseOrderID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/PurchaseOrderHeader.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/PurchaseOrderHeader.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// General purchase order information. See PurchaseOrderDetail.
 /// </summary>
-public partial class PurchaseOrderHeader
-{
+public partial record PurchaseOrderHeader{
     /// <summary>
     /// Primary key.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesOrderDetail.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesOrderDetail.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Individual products associated with a specific sales order. See SalesOrderHeader.
 /// </summary>
-public partial class SalesOrderDetail
-{
+public partial record SalesOrderDetail{
     /// <summary>
     /// Primary key. Foreign key to SalesOrderHeader.SalesOrderID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesOrderHeader.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesOrderHeader.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// General sales order information.
 /// </summary>
-public partial class SalesOrderHeader
-{
+public partial record SalesOrderHeader{
     /// <summary>
     /// Primary key.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesOrderHeaderSalesReason.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesOrderHeaderSalesReason.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping sales orders to sales reason codes.
 /// </summary>
-public partial class SalesOrderHeaderSalesReason
-{
+public partial record SalesOrderHeaderSalesReason{
     /// <summary>
     /// Primary key. Foreign key to SalesOrderHeader.SalesOrderID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesPerson.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesPerson.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Sales representative current information.
 /// </summary>
-public partial class SalesPerson
-{
+public partial record SalesPerson{
     /// <summary>
     /// Primary key for SalesPerson records. Foreign key to Employee.BusinessEntityID
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesPersonQuotaHistory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesPersonQuotaHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Sales performance tracking.
 /// </summary>
-public partial class SalesPersonQuotaHistory
-{
+public partial record SalesPersonQuotaHistory{
     /// <summary>
     /// Sales person identification number. Foreign key to SalesPerson.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesReason.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesReason.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table of customer purchase reasons.
 /// </summary>
-public partial class SalesReason
-{
+public partial record SalesReason{
     /// <summary>
     /// Primary key for SalesReason records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesTaxRate.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesTaxRate.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Tax rate lookup table.
 /// </summary>
-public partial class SalesTaxRate
-{
+public partial record SalesTaxRate{
     /// <summary>
     /// Primary key for SalesTaxRate records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesTerritory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesTerritory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Sales territory lookup table.
 /// </summary>
-public partial class SalesTerritory
-{
+public partial record SalesTerritory{
     /// <summary>
     /// Primary key for SalesTerritory records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesTerritoryHistory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesTerritoryHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Sales representative transfers to other sales territories.
 /// </summary>
-public partial class SalesTerritoryHistory
-{
+public partial record SalesTerritoryHistory{
     /// <summary>
     /// Primary key. The sales rep.  Foreign key to SalesPerson.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ScrapReason.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ScrapReason.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Manufacturing failure reasons lookup table.
 /// </summary>
-public partial class ScrapReason
-{
+public partial record ScrapReason{
     /// <summary>
     /// Primary key for ScrapReason records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Shift.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Shift.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Work shift lookup table.
 /// </summary>
-public partial class Shift
-{
+public partial record Shift{
     /// <summary>
     /// Primary key for Shift records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ShipMethod.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ShipMethod.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Shipping company lookup table.
 /// </summary>
-public partial class ShipMethod
-{
+public partial record ShipMethod{
     /// <summary>
     /// Primary key for ShipMethod records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ShoppingCartItem.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ShoppingCartItem.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Contains online customer orders until the order is submitted or cancelled.
 /// </summary>
-public partial class ShoppingCartItem
-{
+public partial record ShoppingCartItem{
     /// <summary>
     /// Primary key for ShoppingCartItem records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SpecialOffer.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SpecialOffer.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Sale discounts lookup table.
 /// </summary>
-public partial class SpecialOffer
-{
+public partial record SpecialOffer{
     /// <summary>
     /// Primary key for SpecialOffer records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SpecialOfferProduct.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SpecialOfferProduct.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping products to special offer discounts.
 /// </summary>
-public partial class SpecialOfferProduct
-{
+public partial record SpecialOfferProduct{
     /// <summary>
     /// Primary key for SpecialOfferProduct records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/StateProvince.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/StateProvince.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// State and province lookup table.
 /// </summary>
-public partial class StateProvince
-{
+public partial record StateProvince{
     /// <summary>
     /// Primary key for StateProvince records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Store.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Store.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Customers (resellers) of Adventure Works products.
 /// </summary>
-public partial class Store
-{
+public partial record Store{
     /// <summary>
     /// Primary key. Foreign key to Customer.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/TransactionHistory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/TransactionHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Record of each purchase order, sales order, or work order transaction year to date.
 /// </summary>
-public partial class TransactionHistory
-{
+public partial record TransactionHistory{
     /// <summary>
     /// Primary key for TransactionHistory records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/TransactionHistoryArchive.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/TransactionHistoryArchive.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Transactions for previous years.
 /// </summary>
-public partial class TransactionHistoryArchive
-{
+public partial record TransactionHistoryArchive{
     /// <summary>
     /// Primary key for TransactionHistoryArchive records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/UnitMeasure.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/UnitMeasure.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Unit of measure lookup table.
 /// </summary>
-public partial class UnitMeasure
-{
+public partial record UnitMeasure{
     /// <summary>
     /// Primary key.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VAdditionalContactInfo.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VAdditionalContactInfo.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VAdditionalContactInfo
-{
+public partial record VAdditionalContactInfo{
     public int BusinessEntityId { get; set; }
 
     public string FirstName { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VEmployee.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VEmployee.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VEmployee
-{
+public partial record VEmployee{
     public int BusinessEntityId { get; set; }
 
     public string Title { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VEmployeeDepartment.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VEmployeeDepartment.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VEmployeeDepartment
-{
+public partial record VEmployeeDepartment{
     public int BusinessEntityId { get; set; }
 
     public string Title { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VEmployeeDepartmentHistory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VEmployeeDepartmentHistory.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VEmployeeDepartmentHistory
-{
+public partial record VEmployeeDepartmentHistory{
     public int BusinessEntityId { get; set; }
 
     public string Title { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VIndividualCustomer.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VIndividualCustomer.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VIndividualCustomer
-{
+public partial record VIndividualCustomer{
     public int BusinessEntityId { get; set; }
 
     public string Title { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VJobCandidate.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VJobCandidate.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VJobCandidate
-{
+public partial record VJobCandidate{
     public int JobCandidateId { get; set; }
 
     public int? BusinessEntityId { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VJobCandidateEducation.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VJobCandidateEducation.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VJobCandidateEducation
-{
+public partial record VJobCandidateEducation{
     public int JobCandidateId { get; set; }
 
     public string EduLevel { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VJobCandidateEmployment.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VJobCandidateEmployment.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VJobCandidateEmployment
-{
+public partial record VJobCandidateEmployment{
     public int JobCandidateId { get; set; }
 
     public DateTime? EmpStartDate { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VPersonDemographic.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VPersonDemographic.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VPersonDemographic
-{
+public partial record VPersonDemographic{
     public int BusinessEntityId { get; set; }
 
     public decimal? TotalPurchaseYtd { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VProductAndDescription.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VProductAndDescription.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VProductAndDescription
-{
+public partial record VProductAndDescription{
     public int ProductId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VProductModelCatalogDescription.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VProductModelCatalogDescription.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VProductModelCatalogDescription
-{
+public partial record VProductModelCatalogDescription{
     public int ProductModelId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VProductModelInstruction.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VProductModelInstruction.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VProductModelInstruction
-{
+public partial record VProductModelInstruction{
     public int ProductModelId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VSalesPerson.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VSalesPerson.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VSalesPerson
-{
+public partial record VSalesPerson{
     public int BusinessEntityId { get; set; }
 
     public string Title { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VSalesPersonSalesByFiscalYear.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VSalesPersonSalesByFiscalYear.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VSalesPersonSalesByFiscalYear
-{
+public partial record VSalesPersonSalesByFiscalYear{
     public int? SalesPersonId { get; set; }
 
     public string FullName { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VStateProvinceCountryRegion.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VStateProvinceCountryRegion.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VStateProvinceCountryRegion
-{
+public partial record VStateProvinceCountryRegion{
     public int StateProvinceId { get; set; }
 
     public string StateProvinceCode { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VStoreWithAddress.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VStoreWithAddress.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VStoreWithAddress
-{
+public partial record VStoreWithAddress{
     public int BusinessEntityId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VStoreWithContact.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VStoreWithContact.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VStoreWithContact
-{
+public partial record VStoreWithContact{
     public int BusinessEntityId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VStoreWithDemographic.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VStoreWithDemographic.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VStoreWithDemographic
-{
+public partial record VStoreWithDemographic{
     public int BusinessEntityId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VVendorWithAddress.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VVendorWithAddress.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VVendorWithAddress
-{
+public partial record VVendorWithAddress{
     public int BusinessEntityId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VVendorWithContact.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VVendorWithContact.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VVendorWithContact
-{
+public partial record VVendorWithContact{
     public int BusinessEntityId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Vendor.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Vendor.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Companies from whom Adventure Works Cycles purchases parts or other goods.
 /// </summary>
-public partial class Vendor
-{
+public partial record Vendor{
     /// <summary>
     /// Primary key for Vendor records.  Foreign key to BusinessEntity.BusinessEntityID
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/WorkOrder.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/WorkOrder.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Manufacturing work orders.
 /// </summary>
-public partial class WorkOrder
-{
+public partial record WorkOrder{
     /// <summary>
     /// Primary key for WorkOrder records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/WorkOrderRouting.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/WorkOrderRouting.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Work order details.
 /// </summary>
-public partial class WorkOrderRouting
-{
+public partial record WorkOrderRouting{
     /// <summary>
     /// Primary key. Foreign key to WorkOrder.WorkOrderID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Address.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Address.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Street address information for customers, employees, and vendors.
 /// </summary>
-public partial class Address
-{
+public partial record Address{
     /// <summary>
     /// Primary key for Address records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/AddressType.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/AddressType.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Types of addresses stored in the Address table. 
 /// </summary>
-public partial class AddressType
-{
+public partial record AddressType{
     /// <summary>
     /// Primary key for AddressType records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/AdventureWorksDbContext.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/AdventureWorksDbContext.cs
@@ -790,7 +790,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("Employee", "HumanResources", tb =>
                 {
                     tb.HasComment("Employee information such as salary, department, and title.");
-                    tb.HasTrigger("dEmployee");
                 });
 
             entity.HasIndex(e => e.LoginId, "AK_Employee_LoginID").IsUnique();
@@ -1059,7 +1058,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("Person", "Person", tb =>
                 {
                     tb.HasComment("Human beings involved with AdventureWorks: employees, customer contacts, and vendor contacts.");
-                    tb.HasTrigger("iuPerson");
                 });
 
             entity.HasIndex(e => e.Rowguid, "AK_Person_rowguid").IsUnique();
@@ -1727,8 +1725,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("PurchaseOrderDetail", "Purchasing", tb =>
                 {
                     tb.HasComment("Individual products associated with a specific purchase order. See PurchaseOrderHeader.");
-                    tb.HasTrigger("iPurchaseOrderDetail");
-                    tb.HasTrigger("uPurchaseOrderDetail");
                 });
 
             entity.HasIndex(e => e.ProductId, "IX_PurchaseOrderDetail_ProductID");
@@ -1785,7 +1781,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("PurchaseOrderHeader", "Purchasing", tb =>
                 {
                     tb.HasComment("General purchase order information. See PurchaseOrderDetail.");
-                    tb.HasTrigger("uPurchaseOrderHeader");
                 });
 
             entity.HasIndex(e => e.EmployeeId, "IX_PurchaseOrderHeader_EmployeeID");
@@ -1853,7 +1848,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("SalesOrderDetail", "Sales", tb =>
                 {
                     tb.HasComment("Individual products associated with a specific sales order. See SalesOrderHeader.");
-                    tb.HasTrigger("iduSalesOrderDetail");
                 });
 
             entity.HasIndex(e => e.Rowguid, "AK_SalesOrderDetail_rowguid").IsUnique();
@@ -1911,7 +1905,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("SalesOrderHeader", "Sales", tb =>
                 {
                     tb.HasComment("General sales order information.");
-                    tb.HasTrigger("uSalesOrderHeader");
                 });
 
             entity.HasIndex(e => e.SalesOrderNumber, "AK_SalesOrderHeader_SalesOrderNumber").IsUnique();
@@ -3305,7 +3298,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("Vendor", "Purchasing", tb =>
                 {
                     tb.HasComment("Companies from whom Adventure Works Cycles purchases parts or other goods.");
-                    tb.HasTrigger("dVendor");
                 });
 
             entity.HasIndex(e => e.AccountNumber, "AK_Vendor_AccountNumber").IsUnique();
@@ -3350,8 +3342,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("WorkOrder", "Production", tb =>
                 {
                     tb.HasComment("Manufacturing work orders.");
-                    tb.HasTrigger("iWorkOrder");
-                    tb.HasTrigger("uWorkOrder");
                 });
 
             entity.HasIndex(e => e.ProductId, "IX_WorkOrder_ProductID");

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/AwbuildVersion.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/AwbuildVersion.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Current version number of the AdventureWorks 2016 sample database. 
 /// </summary>
-public partial class AwbuildVersion
-{
+public partial record AwbuildVersion{
     /// <summary>
     /// Primary key for AWBuildVersion records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/BillOfMaterial.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/BillOfMaterial.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Items required to make bicycles and bicycle subassemblies. It identifies the heirarchical relationship between a parent product and its components.
 /// </summary>
-public partial class BillOfMaterial
-{
+public partial record BillOfMaterial{
     /// <summary>
     /// Primary key for BillOfMaterials records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/BusinessEntity.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/BusinessEntity.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Source of the ID that connects vendors, customers, and employees with address and contact information.
 /// </summary>
-public partial class BusinessEntity
-{
+public partial record BusinessEntity{
     /// <summary>
     /// Primary key for all customers, vendors, and employees.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/BusinessEntityAddress.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/BusinessEntityAddress.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping customers, vendors, and employees to their addresses.
 /// </summary>
-public partial class BusinessEntityAddress
-{
+public partial record BusinessEntityAddress{
     /// <summary>
     /// Primary key. Foreign key to BusinessEntity.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/BusinessEntityContact.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/BusinessEntityContact.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping stores, vendors, and employees to people
 /// </summary>
-public partial class BusinessEntityContact
-{
+public partial record BusinessEntityContact{
     /// <summary>
     /// Primary key. Foreign key to BusinessEntity.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ContactType.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ContactType.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table containing the types of business entity contacts.
 /// </summary>
-public partial class ContactType
-{
+public partial record ContactType{
     /// <summary>
     /// Primary key for ContactType records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/CountryRegion.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/CountryRegion.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table containing the ISO standard codes for countries and regions.
 /// </summary>
-public partial class CountryRegion
-{
+public partial record CountryRegion{
     /// <summary>
     /// ISO standard code for countries and regions.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/CountryRegionCurrency.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/CountryRegionCurrency.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping ISO currency codes to a country or region.
 /// </summary>
-public partial class CountryRegionCurrency
-{
+public partial record CountryRegionCurrency{
     /// <summary>
     /// ISO code for countries and regions. Foreign key to CountryRegion.CountryRegionCode.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/CreditCard.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/CreditCard.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Customer credit card information.
 /// </summary>
-public partial class CreditCard
-{
+public partial record CreditCard{
     /// <summary>
     /// Primary key for CreditCard records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Culture.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Culture.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table containing the languages in which some AdventureWorks data is stored.
 /// </summary>
-public partial class Culture
-{
+public partial record Culture{
     /// <summary>
     /// Primary key for Culture records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Currency.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Currency.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table containing standard ISO currencies.
 /// </summary>
-public partial class Currency
-{
+public partial record Currency{
     /// <summary>
     /// The ISO code for the Currency.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/CurrencyRate.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/CurrencyRate.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Currency exchange rates.
 /// </summary>
-public partial class CurrencyRate
-{
+public partial record CurrencyRate{
     /// <summary>
     /// Primary key for CurrencyRate records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Customer.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Customer.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Current customer information. Also see the Person and Store tables.
 /// </summary>
-public partial class Customer
-{
+public partial record Customer{
     /// <summary>
     /// Primary key.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/DatabaseLog.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/DatabaseLog.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Audit table tracking all DDL changes made to the AdventureWorks database. Data is captured by the database trigger ddlDatabaseTriggerLog.
 /// </summary>
-public partial class DatabaseLog
-{
+public partial record DatabaseLog{
     /// <summary>
     /// Primary key for DatabaseLog records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Department.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Department.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table containing the departments within the Adventure Works Cycles company.
 /// </summary>
-public partial class Department
-{
+public partial record Department{
     /// <summary>
     /// Primary key for Department records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/EmailAddress.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/EmailAddress.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Where to send a person email.
 /// </summary>
-public partial class EmailAddress
-{
+public partial record EmailAddress{
     /// <summary>
     /// Primary key. Person associated with this email address.  Foreign key to Person.BusinessEntityID
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Employee.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Employee.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Employee information such as salary, department, and title.
 /// </summary>
-public partial class Employee
-{
+public partial record Employee{
     /// <summary>
     /// Primary key for Employee records.  Foreign key to BusinessEntity.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/EmployeeDepartmentHistory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/EmployeeDepartmentHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Employee department transfers.
 /// </summary>
-public partial class EmployeeDepartmentHistory
-{
+public partial record EmployeeDepartmentHistory{
     /// <summary>
     /// Employee identification number. Foreign key to Employee.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/EmployeePayHistory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/EmployeePayHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Employee pay history.
 /// </summary>
-public partial class EmployeePayHistory
-{
+public partial record EmployeePayHistory{
     /// <summary>
     /// Employee identification number. Foreign key to Employee.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ErrorLog.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ErrorLog.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Audit table tracking errors in the the AdventureWorks database that are caught by the CATCH block of a TRY...CATCH construct. Data is inserted by stored procedure dbo.uspLogError when it is executed from inside the CATCH block of a TRY...CATCH construct.
 /// </summary>
-public partial class ErrorLog
-{
+public partial record ErrorLog{
     /// <summary>
     /// Primary key for ErrorLog records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Illustration.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Illustration.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Bicycle assembly diagrams.
 /// </summary>
-public partial class Illustration
-{
+public partial record Illustration{
     /// <summary>
     /// Primary key for Illustration records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/JobCandidate.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/JobCandidate.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Résumés submitted to Human Resources by job applicants.
 /// </summary>
-public partial class JobCandidate
-{
+public partial record JobCandidate{
     /// <summary>
     /// Primary key for JobCandidate records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Location.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Location.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product inventory and manufacturing locations.
 /// </summary>
-public partial class Location
-{
+public partial record Location{
     /// <summary>
     /// Primary key for Location records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Password.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Password.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// One way hashed authentication information
 /// </summary>
-public partial class Password
-{
+public partial record Password{
     public int BusinessEntityId { get; set; }
 
     /// <summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Person.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Person.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Human beings involved with AdventureWorks: employees, customer contacts, and vendor contacts.
 /// </summary>
-public partial class Person
-{
+public partial record Person{
     /// <summary>
     /// Primary key for Person records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/PersonCreditCard.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/PersonCreditCard.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping people to their credit card information in the CreditCard table. 
 /// </summary>
-public partial class PersonCreditCard
-{
+public partial record PersonCreditCard{
     /// <summary>
     /// Business entity identification number. Foreign key to Person.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/PersonPhone.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/PersonPhone.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Telephone number and type of a person.
 /// </summary>
-public partial class PersonPhone
-{
+public partial record PersonPhone{
     /// <summary>
     /// Business entity identification number. Foreign key to Person.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/PhoneNumberType.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/PhoneNumberType.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Type of phone number of a person.
 /// </summary>
-public partial class PhoneNumberType
-{
+public partial record PhoneNumberType{
     /// <summary>
     /// Primary key for telephone number type records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Product.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Product.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Products sold or used in the manfacturing of sold products.
 /// </summary>
-public partial class Product
-{
+public partial record Product{
     /// <summary>
     /// Primary key for Product records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductCategory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductCategory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// High-level product categorization.
 /// </summary>
-public partial class ProductCategory
-{
+public partial record ProductCategory{
     /// <summary>
     /// Primary key for ProductCategory records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductCostHistory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductCostHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Changes in the cost of a product over time.
 /// </summary>
-public partial class ProductCostHistory
-{
+public partial record ProductCostHistory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductDescription.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductDescription.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product descriptions in several languages.
 /// </summary>
-public partial class ProductDescription
-{
+public partial record ProductDescription{
     /// <summary>
     /// Primary key for ProductDescription records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductInventory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductInventory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product inventory information.
 /// </summary>
-public partial class ProductInventory
-{
+public partial record ProductInventory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductListPriceHistory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductListPriceHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Changes in the list price of a product over time.
 /// </summary>
-public partial class ProductListPriceHistory
-{
+public partial record ProductListPriceHistory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductModel.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductModel.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product model classification.
 /// </summary>
-public partial class ProductModel
-{
+public partial record ProductModel{
     /// <summary>
     /// Primary key for ProductModel records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductModelIllustration.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductModelIllustration.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping product models and illustrations.
 /// </summary>
-public partial class ProductModelIllustration
-{
+public partial record ProductModelIllustration{
     /// <summary>
     /// Primary key. Foreign key to ProductModel.ProductModelID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductModelProductDescriptionCulture.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductModelProductDescriptionCulture.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping product descriptions and the language the description is written in.
 /// </summary>
-public partial class ProductModelProductDescriptionCulture
-{
+public partial record ProductModelProductDescriptionCulture{
     /// <summary>
     /// Primary key. Foreign key to ProductModel.ProductModelID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductPhoto.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductPhoto.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product images.
 /// </summary>
-public partial class ProductPhoto
-{
+public partial record ProductPhoto{
     /// <summary>
     /// Primary key for ProductPhoto records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductProductPhoto.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductProductPhoto.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping products and product photos.
 /// </summary>
-public partial class ProductProductPhoto
-{
+public partial record ProductProductPhoto{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductReview.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductReview.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Customer reviews of products they have purchased.
 /// </summary>
-public partial class ProductReview
-{
+public partial record ProductReview{
     /// <summary>
     /// Primary key for ProductReview records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductSubcategory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductSubcategory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product subcategories. See ProductCategory table.
 /// </summary>
-public partial class ProductSubcategory
-{
+public partial record ProductSubcategory{
     /// <summary>
     /// Primary key for ProductSubcategory records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductVendor.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductVendor.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping vendors with the products they supply.
 /// </summary>
-public partial class ProductVendor
-{
+public partial record ProductVendor{
     /// <summary>
     /// Primary key. Foreign key to Product.ProductID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/PurchaseOrderDetail.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/PurchaseOrderDetail.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Individual products associated with a specific purchase order. See PurchaseOrderHeader.
 /// </summary>
-public partial class PurchaseOrderDetail
-{
+public partial record PurchaseOrderDetail{
     /// <summary>
     /// Primary key. Foreign key to PurchaseOrderHeader.PurchaseOrderID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/PurchaseOrderHeader.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/PurchaseOrderHeader.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// General purchase order information. See PurchaseOrderDetail.
 /// </summary>
-public partial class PurchaseOrderHeader
-{
+public partial record PurchaseOrderHeader{
     /// <summary>
     /// Primary key.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesOrderDetail.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesOrderDetail.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Individual products associated with a specific sales order. See SalesOrderHeader.
 /// </summary>
-public partial class SalesOrderDetail
-{
+public partial record SalesOrderDetail{
     /// <summary>
     /// Primary key. Foreign key to SalesOrderHeader.SalesOrderID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesOrderHeader.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesOrderHeader.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// General sales order information.
 /// </summary>
-public partial class SalesOrderHeader
-{
+public partial record SalesOrderHeader{
     /// <summary>
     /// Primary key.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesOrderHeaderSalesReason.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesOrderHeaderSalesReason.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping sales orders to sales reason codes.
 /// </summary>
-public partial class SalesOrderHeaderSalesReason
-{
+public partial record SalesOrderHeaderSalesReason{
     /// <summary>
     /// Primary key. Foreign key to SalesOrderHeader.SalesOrderID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesPerson.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesPerson.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Sales representative current information.
 /// </summary>
-public partial class SalesPerson
-{
+public partial record SalesPerson{
     /// <summary>
     /// Primary key for SalesPerson records. Foreign key to Employee.BusinessEntityID
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesPersonQuotaHistory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesPersonQuotaHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Sales performance tracking.
 /// </summary>
-public partial class SalesPersonQuotaHistory
-{
+public partial record SalesPersonQuotaHistory{
     /// <summary>
     /// Sales person identification number. Foreign key to SalesPerson.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesReason.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesReason.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table of customer purchase reasons.
 /// </summary>
-public partial class SalesReason
-{
+public partial record SalesReason{
     /// <summary>
     /// Primary key for SalesReason records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesTaxRate.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesTaxRate.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Tax rate lookup table.
 /// </summary>
-public partial class SalesTaxRate
-{
+public partial record SalesTaxRate{
     /// <summary>
     /// Primary key for SalesTaxRate records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesTerritory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesTerritory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Sales territory lookup table.
 /// </summary>
-public partial class SalesTerritory
-{
+public partial record SalesTerritory{
     /// <summary>
     /// Primary key for SalesTerritory records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesTerritoryHistory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesTerritoryHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Sales representative transfers to other sales territories.
 /// </summary>
-public partial class SalesTerritoryHistory
-{
+public partial record SalesTerritoryHistory{
     /// <summary>
     /// Primary key. The sales rep.  Foreign key to SalesPerson.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ScrapReason.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ScrapReason.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Manufacturing failure reasons lookup table.
 /// </summary>
-public partial class ScrapReason
-{
+public partial record ScrapReason{
     /// <summary>
     /// Primary key for ScrapReason records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Shift.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Shift.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Work shift lookup table.
 /// </summary>
-public partial class Shift
-{
+public partial record Shift{
     /// <summary>
     /// Primary key for Shift records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ShipMethod.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ShipMethod.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Shipping company lookup table.
 /// </summary>
-public partial class ShipMethod
-{
+public partial record ShipMethod{
     /// <summary>
     /// Primary key for ShipMethod records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ShoppingCartItem.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ShoppingCartItem.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Contains online customer orders until the order is submitted or cancelled.
 /// </summary>
-public partial class ShoppingCartItem
-{
+public partial record ShoppingCartItem{
     /// <summary>
     /// Primary key for ShoppingCartItem records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SpecialOffer.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SpecialOffer.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Sale discounts lookup table.
 /// </summary>
-public partial class SpecialOffer
-{
+public partial record SpecialOffer{
     /// <summary>
     /// Primary key for SpecialOffer records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SpecialOfferProduct.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SpecialOfferProduct.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping products to special offer discounts.
 /// </summary>
-public partial class SpecialOfferProduct
-{
+public partial record SpecialOfferProduct{
     /// <summary>
     /// Primary key for SpecialOfferProduct records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/StateProvince.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/StateProvince.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// State and province lookup table.
 /// </summary>
-public partial class StateProvince
-{
+public partial record StateProvince{
     /// <summary>
     /// Primary key for StateProvince records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Store.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Store.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Customers (resellers) of Adventure Works products.
 /// </summary>
-public partial class Store
-{
+public partial record Store{
     /// <summary>
     /// Primary key. Foreign key to Customer.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/TransactionHistory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/TransactionHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Record of each purchase order, sales order, or work order transaction year to date.
 /// </summary>
-public partial class TransactionHistory
-{
+public partial record TransactionHistory{
     /// <summary>
     /// Primary key for TransactionHistory records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/TransactionHistoryArchive.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/TransactionHistoryArchive.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Transactions for previous years.
 /// </summary>
-public partial class TransactionHistoryArchive
-{
+public partial record TransactionHistoryArchive{
     /// <summary>
     /// Primary key for TransactionHistoryArchive records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/UnitMeasure.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/UnitMeasure.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Unit of measure lookup table.
 /// </summary>
-public partial class UnitMeasure
-{
+public partial record UnitMeasure{
     /// <summary>
     /// Primary key.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VAdditionalContactInfo.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VAdditionalContactInfo.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VAdditionalContactInfo
-{
+public partial record VAdditionalContactInfo{
     public int BusinessEntityId { get; set; }
 
     public string FirstName { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VEmployee.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VEmployee.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VEmployee
-{
+public partial record VEmployee{
     public int BusinessEntityId { get; set; }
 
     public string Title { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VEmployeeDepartment.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VEmployeeDepartment.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VEmployeeDepartment
-{
+public partial record VEmployeeDepartment{
     public int BusinessEntityId { get; set; }
 
     public string Title { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VEmployeeDepartmentHistory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VEmployeeDepartmentHistory.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VEmployeeDepartmentHistory
-{
+public partial record VEmployeeDepartmentHistory{
     public int BusinessEntityId { get; set; }
 
     public string Title { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VIndividualCustomer.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VIndividualCustomer.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VIndividualCustomer
-{
+public partial record VIndividualCustomer{
     public int BusinessEntityId { get; set; }
 
     public string Title { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VJobCandidate.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VJobCandidate.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VJobCandidate
-{
+public partial record VJobCandidate{
     public int JobCandidateId { get; set; }
 
     public int? BusinessEntityId { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VJobCandidateEducation.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VJobCandidateEducation.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VJobCandidateEducation
-{
+public partial record VJobCandidateEducation{
     public int JobCandidateId { get; set; }
 
     public string EduLevel { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VJobCandidateEmployment.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VJobCandidateEmployment.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VJobCandidateEmployment
-{
+public partial record VJobCandidateEmployment{
     public int JobCandidateId { get; set; }
 
     public DateTime? EmpStartDate { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VPersonDemographic.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VPersonDemographic.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VPersonDemographic
-{
+public partial record VPersonDemographic{
     public int BusinessEntityId { get; set; }
 
     public decimal? TotalPurchaseYtd { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VProductAndDescription.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VProductAndDescription.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VProductAndDescription
-{
+public partial record VProductAndDescription{
     public int ProductId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VProductModelCatalogDescription.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VProductModelCatalogDescription.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VProductModelCatalogDescription
-{
+public partial record VProductModelCatalogDescription{
     public int ProductModelId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VProductModelInstruction.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VProductModelInstruction.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VProductModelInstruction
-{
+public partial record VProductModelInstruction{
     public int ProductModelId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VSalesPerson.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VSalesPerson.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VSalesPerson
-{
+public partial record VSalesPerson{
     public int BusinessEntityId { get; set; }
 
     public string Title { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VSalesPersonSalesByFiscalYear.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VSalesPersonSalesByFiscalYear.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VSalesPersonSalesByFiscalYear
-{
+public partial record VSalesPersonSalesByFiscalYear{
     public int? SalesPersonId { get; set; }
 
     public string FullName { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VStateProvinceCountryRegion.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VStateProvinceCountryRegion.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VStateProvinceCountryRegion
-{
+public partial record VStateProvinceCountryRegion{
     public int StateProvinceId { get; set; }
 
     public string StateProvinceCode { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VStoreWithAddress.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VStoreWithAddress.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VStoreWithAddress
-{
+public partial record VStoreWithAddress{
     public int BusinessEntityId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VStoreWithContact.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VStoreWithContact.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VStoreWithContact
-{
+public partial record VStoreWithContact{
     public int BusinessEntityId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VStoreWithDemographic.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VStoreWithDemographic.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VStoreWithDemographic
-{
+public partial record VStoreWithDemographic{
     public int BusinessEntityId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VVendorWithAddress.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VVendorWithAddress.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VVendorWithAddress
-{
+public partial record VVendorWithAddress{
     public int BusinessEntityId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VVendorWithContact.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VVendorWithContact.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VVendorWithContact
-{
+public partial record VVendorWithContact{
     public int BusinessEntityId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Vendor.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Vendor.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Companies from whom Adventure Works Cycles purchases parts or other goods.
 /// </summary>
-public partial class Vendor
-{
+public partial record Vendor{
     /// <summary>
     /// Primary key for Vendor records.  Foreign key to BusinessEntity.BusinessEntityID
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/WorkOrder.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/WorkOrder.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Manufacturing work orders.
 /// </summary>
-public partial class WorkOrder
-{
+public partial record WorkOrder{
     /// <summary>
     /// Primary key for WorkOrder records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/WorkOrderRouting.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/WorkOrderRouting.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Work order details.
 /// </summary>
-public partial class WorkOrderRouting
-{
+public partial record WorkOrderRouting{
     /// <summary>
     /// Primary key. Foreign key to WorkOrder.WorkOrderID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Address.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Address.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Street address information for customers, employees, and vendors.
 /// </summary>
-public partial class Address
-{
+public partial record Address{
     /// <summary>
     /// Primary key for Address records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/AddressType.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/AddressType.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Types of addresses stored in the Address table. 
 /// </summary>
-public partial class AddressType
-{
+public partial record AddressType{
     /// <summary>
     /// Primary key for AddressType records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/AdventureWorksDbContext.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/AdventureWorksDbContext.cs
@@ -790,7 +790,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("Employee", "HumanResources", tb =>
                 {
                     tb.HasComment("Employee information such as salary, department, and title.");
-                    tb.HasTrigger("dEmployee");
                 });
 
             entity.HasIndex(e => e.LoginId, "AK_Employee_LoginID").IsUnique();
@@ -1059,7 +1058,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("Person", "Person", tb =>
                 {
                     tb.HasComment("Human beings involved with AdventureWorks: employees, customer contacts, and vendor contacts.");
-                    tb.HasTrigger("iuPerson");
                 });
 
             entity.HasIndex(e => e.Rowguid, "AK_Person_rowguid").IsUnique();
@@ -1727,8 +1725,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("PurchaseOrderDetail", "Purchasing", tb =>
                 {
                     tb.HasComment("Individual products associated with a specific purchase order. See PurchaseOrderHeader.");
-                    tb.HasTrigger("iPurchaseOrderDetail");
-                    tb.HasTrigger("uPurchaseOrderDetail");
                 });
 
             entity.HasIndex(e => e.ProductId, "IX_PurchaseOrderDetail_ProductID");
@@ -1785,7 +1781,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("PurchaseOrderHeader", "Purchasing", tb =>
                 {
                     tb.HasComment("General purchase order information. See PurchaseOrderDetail.");
-                    tb.HasTrigger("uPurchaseOrderHeader");
                 });
 
             entity.HasIndex(e => e.EmployeeId, "IX_PurchaseOrderHeader_EmployeeID");
@@ -1853,7 +1848,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("SalesOrderDetail", "Sales", tb =>
                 {
                     tb.HasComment("Individual products associated with a specific sales order. See SalesOrderHeader.");
-                    tb.HasTrigger("iduSalesOrderDetail");
                 });
 
             entity.HasIndex(e => e.Rowguid, "AK_SalesOrderDetail_rowguid").IsUnique();
@@ -1911,7 +1905,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("SalesOrderHeader", "Sales", tb =>
                 {
                     tb.HasComment("General sales order information.");
-                    tb.HasTrigger("uSalesOrderHeader");
                 });
 
             entity.HasIndex(e => e.SalesOrderNumber, "AK_SalesOrderHeader_SalesOrderNumber").IsUnique();
@@ -3305,7 +3298,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("Vendor", "Purchasing", tb =>
                 {
                     tb.HasComment("Companies from whom Adventure Works Cycles purchases parts or other goods.");
-                    tb.HasTrigger("dVendor");
                 });
 
             entity.HasIndex(e => e.AccountNumber, "AK_Vendor_AccountNumber").IsUnique();
@@ -3350,8 +3342,6 @@ public partial class AdventureWorksDbContext : DbContext
             entity.ToTable("WorkOrder", "Production", tb =>
                 {
                     tb.HasComment("Manufacturing work orders.");
-                    tb.HasTrigger("iWorkOrder");
-                    tb.HasTrigger("uWorkOrder");
                 });
 
             entity.HasIndex(e => e.ProductId, "IX_WorkOrder_ProductID");

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/AwbuildVersion.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/AwbuildVersion.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Current version number of the AdventureWorks 2016 sample database. 
 /// </summary>
-public partial class AwbuildVersion
-{
+public partial record AwbuildVersion{
     /// <summary>
     /// Primary key for AWBuildVersion records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/BillOfMaterial.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/BillOfMaterial.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Items required to make bicycles and bicycle subassemblies. It identifies the heirarchical relationship between a parent product and its components.
 /// </summary>
-public partial class BillOfMaterial
-{
+public partial record BillOfMaterial{
     /// <summary>
     /// Primary key for BillOfMaterials records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/BusinessEntity.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/BusinessEntity.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Source of the ID that connects vendors, customers, and employees with address and contact information.
 /// </summary>
-public partial class BusinessEntity
-{
+public partial record BusinessEntity{
     /// <summary>
     /// Primary key for all customers, vendors, and employees.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/BusinessEntityAddress.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/BusinessEntityAddress.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping customers, vendors, and employees to their addresses.
 /// </summary>
-public partial class BusinessEntityAddress
-{
+public partial record BusinessEntityAddress{
     /// <summary>
     /// Primary key. Foreign key to BusinessEntity.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/BusinessEntityContact.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/BusinessEntityContact.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping stores, vendors, and employees to people
 /// </summary>
-public partial class BusinessEntityContact
-{
+public partial record BusinessEntityContact{
     /// <summary>
     /// Primary key. Foreign key to BusinessEntity.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ContactType.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ContactType.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table containing the types of business entity contacts.
 /// </summary>
-public partial class ContactType
-{
+public partial record ContactType{
     /// <summary>
     /// Primary key for ContactType records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/CountryRegion.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/CountryRegion.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table containing the ISO standard codes for countries and regions.
 /// </summary>
-public partial class CountryRegion
-{
+public partial record CountryRegion{
     /// <summary>
     /// ISO standard code for countries and regions.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/CountryRegionCurrency.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/CountryRegionCurrency.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping ISO currency codes to a country or region.
 /// </summary>
-public partial class CountryRegionCurrency
-{
+public partial record CountryRegionCurrency{
     /// <summary>
     /// ISO code for countries and regions. Foreign key to CountryRegion.CountryRegionCode.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/CreditCard.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/CreditCard.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Customer credit card information.
 /// </summary>
-public partial class CreditCard
-{
+public partial record CreditCard{
     /// <summary>
     /// Primary key for CreditCard records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Culture.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Culture.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table containing the languages in which some AdventureWorks data is stored.
 /// </summary>
-public partial class Culture
-{
+public partial record Culture{
     /// <summary>
     /// Primary key for Culture records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Currency.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Currency.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table containing standard ISO currencies.
 /// </summary>
-public partial class Currency
-{
+public partial record Currency{
     /// <summary>
     /// The ISO code for the Currency.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/CurrencyRate.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/CurrencyRate.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Currency exchange rates.
 /// </summary>
-public partial class CurrencyRate
-{
+public partial record CurrencyRate{
     /// <summary>
     /// Primary key for CurrencyRate records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Customer.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Customer.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Current customer information. Also see the Person and Store tables.
 /// </summary>
-public partial class Customer
-{
+public partial record Customer{
     /// <summary>
     /// Primary key.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/DatabaseLog.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/DatabaseLog.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Audit table tracking all DDL changes made to the AdventureWorks database. Data is captured by the database trigger ddlDatabaseTriggerLog.
 /// </summary>
-public partial class DatabaseLog
-{
+public partial record DatabaseLog{
     /// <summary>
     /// Primary key for DatabaseLog records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Department.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Department.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table containing the departments within the Adventure Works Cycles company.
 /// </summary>
-public partial class Department
-{
+public partial record Department{
     /// <summary>
     /// Primary key for Department records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/EmailAddress.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/EmailAddress.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Where to send a person email.
 /// </summary>
-public partial class EmailAddress
-{
+public partial record EmailAddress{
     /// <summary>
     /// Primary key. Person associated with this email address.  Foreign key to Person.BusinessEntityID
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Employee.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Employee.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Employee information such as salary, department, and title.
 /// </summary>
-public partial class Employee
-{
+public partial record Employee{
     /// <summary>
     /// Primary key for Employee records.  Foreign key to BusinessEntity.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/EmployeeDepartmentHistory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/EmployeeDepartmentHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Employee department transfers.
 /// </summary>
-public partial class EmployeeDepartmentHistory
-{
+public partial record EmployeeDepartmentHistory{
     /// <summary>
     /// Employee identification number. Foreign key to Employee.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/EmployeePayHistory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/EmployeePayHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Employee pay history.
 /// </summary>
-public partial class EmployeePayHistory
-{
+public partial record EmployeePayHistory{
     /// <summary>
     /// Employee identification number. Foreign key to Employee.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ErrorLog.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ErrorLog.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Audit table tracking errors in the the AdventureWorks database that are caught by the CATCH block of a TRY...CATCH construct. Data is inserted by stored procedure dbo.uspLogError when it is executed from inside the CATCH block of a TRY...CATCH construct.
 /// </summary>
-public partial class ErrorLog
-{
+public partial record ErrorLog{
     /// <summary>
     /// Primary key for ErrorLog records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Illustration.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Illustration.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Bicycle assembly diagrams.
 /// </summary>
-public partial class Illustration
-{
+public partial record Illustration{
     /// <summary>
     /// Primary key for Illustration records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/JobCandidate.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/JobCandidate.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Résumés submitted to Human Resources by job applicants.
 /// </summary>
-public partial class JobCandidate
-{
+public partial record JobCandidate{
     /// <summary>
     /// Primary key for JobCandidate records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Location.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Location.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product inventory and manufacturing locations.
 /// </summary>
-public partial class Location
-{
+public partial record Location{
     /// <summary>
     /// Primary key for Location records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Password.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Password.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// One way hashed authentication information
 /// </summary>
-public partial class Password
-{
+public partial record Password{
     public int BusinessEntityId { get; set; }
 
     /// <summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Person.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Person.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Human beings involved with AdventureWorks: employees, customer contacts, and vendor contacts.
 /// </summary>
-public partial class Person
-{
+public partial record Person{
     /// <summary>
     /// Primary key for Person records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/PersonCreditCard.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/PersonCreditCard.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping people to their credit card information in the CreditCard table. 
 /// </summary>
-public partial class PersonCreditCard
-{
+public partial record PersonCreditCard{
     /// <summary>
     /// Business entity identification number. Foreign key to Person.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/PersonPhone.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/PersonPhone.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Telephone number and type of a person.
 /// </summary>
-public partial class PersonPhone
-{
+public partial record PersonPhone{
     /// <summary>
     /// Business entity identification number. Foreign key to Person.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/PhoneNumberType.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/PhoneNumberType.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Type of phone number of a person.
 /// </summary>
-public partial class PhoneNumberType
-{
+public partial record PhoneNumberType{
     /// <summary>
     /// Primary key for telephone number type records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Product.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Product.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Products sold or used in the manfacturing of sold products.
 /// </summary>
-public partial class Product
-{
+public partial record Product{
     /// <summary>
     /// Primary key for Product records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductCategory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductCategory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// High-level product categorization.
 /// </summary>
-public partial class ProductCategory
-{
+public partial record ProductCategory{
     /// <summary>
     /// Primary key for ProductCategory records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductCostHistory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductCostHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Changes in the cost of a product over time.
 /// </summary>
-public partial class ProductCostHistory
-{
+public partial record ProductCostHistory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductDescription.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductDescription.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product descriptions in several languages.
 /// </summary>
-public partial class ProductDescription
-{
+public partial record ProductDescription{
     /// <summary>
     /// Primary key for ProductDescription records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductInventory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductInventory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product inventory information.
 /// </summary>
-public partial class ProductInventory
-{
+public partial record ProductInventory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductListPriceHistory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductListPriceHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Changes in the list price of a product over time.
 /// </summary>
-public partial class ProductListPriceHistory
-{
+public partial record ProductListPriceHistory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductModel.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductModel.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product model classification.
 /// </summary>
-public partial class ProductModel
-{
+public partial record ProductModel{
     /// <summary>
     /// Primary key for ProductModel records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductModelIllustration.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductModelIllustration.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping product models and illustrations.
 /// </summary>
-public partial class ProductModelIllustration
-{
+public partial record ProductModelIllustration{
     /// <summary>
     /// Primary key. Foreign key to ProductModel.ProductModelID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductModelProductDescriptionCulture.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductModelProductDescriptionCulture.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping product descriptions and the language the description is written in.
 /// </summary>
-public partial class ProductModelProductDescriptionCulture
-{
+public partial record ProductModelProductDescriptionCulture{
     /// <summary>
     /// Primary key. Foreign key to ProductModel.ProductModelID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductPhoto.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductPhoto.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product images.
 /// </summary>
-public partial class ProductPhoto
-{
+public partial record ProductPhoto{
     /// <summary>
     /// Primary key for ProductPhoto records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductProductPhoto.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductProductPhoto.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping products and product photos.
 /// </summary>
-public partial class ProductProductPhoto
-{
+public partial record ProductProductPhoto{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductReview.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductReview.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Customer reviews of products they have purchased.
 /// </summary>
-public partial class ProductReview
-{
+public partial record ProductReview{
     /// <summary>
     /// Primary key for ProductReview records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductSubcategory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductSubcategory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Product subcategories. See ProductCategory table.
 /// </summary>
-public partial class ProductSubcategory
-{
+public partial record ProductSubcategory{
     /// <summary>
     /// Primary key for ProductSubcategory records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductVendor.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductVendor.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping vendors with the products they supply.
 /// </summary>
-public partial class ProductVendor
-{
+public partial record ProductVendor{
     /// <summary>
     /// Primary key. Foreign key to Product.ProductID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/PurchaseOrderDetail.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/PurchaseOrderDetail.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Individual products associated with a specific purchase order. See PurchaseOrderHeader.
 /// </summary>
-public partial class PurchaseOrderDetail
-{
+public partial record PurchaseOrderDetail{
     /// <summary>
     /// Primary key. Foreign key to PurchaseOrderHeader.PurchaseOrderID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/PurchaseOrderHeader.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/PurchaseOrderHeader.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// General purchase order information. See PurchaseOrderDetail.
 /// </summary>
-public partial class PurchaseOrderHeader
-{
+public partial record PurchaseOrderHeader{
     /// <summary>
     /// Primary key.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesOrderDetail.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesOrderDetail.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Individual products associated with a specific sales order. See SalesOrderHeader.
 /// </summary>
-public partial class SalesOrderDetail
-{
+public partial record SalesOrderDetail{
     /// <summary>
     /// Primary key. Foreign key to SalesOrderHeader.SalesOrderID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesOrderHeader.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesOrderHeader.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// General sales order information.
 /// </summary>
-public partial class SalesOrderHeader
-{
+public partial record SalesOrderHeader{
     /// <summary>
     /// Primary key.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesOrderHeaderSalesReason.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesOrderHeaderSalesReason.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping sales orders to sales reason codes.
 /// </summary>
-public partial class SalesOrderHeaderSalesReason
-{
+public partial record SalesOrderHeaderSalesReason{
     /// <summary>
     /// Primary key. Foreign key to SalesOrderHeader.SalesOrderID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesPerson.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesPerson.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Sales representative current information.
 /// </summary>
-public partial class SalesPerson
-{
+public partial record SalesPerson{
     /// <summary>
     /// Primary key for SalesPerson records. Foreign key to Employee.BusinessEntityID
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesPersonQuotaHistory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesPersonQuotaHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Sales performance tracking.
 /// </summary>
-public partial class SalesPersonQuotaHistory
-{
+public partial record SalesPersonQuotaHistory{
     /// <summary>
     /// Sales person identification number. Foreign key to SalesPerson.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesReason.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesReason.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Lookup table of customer purchase reasons.
 /// </summary>
-public partial class SalesReason
-{
+public partial record SalesReason{
     /// <summary>
     /// Primary key for SalesReason records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesTaxRate.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesTaxRate.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Tax rate lookup table.
 /// </summary>
-public partial class SalesTaxRate
-{
+public partial record SalesTaxRate{
     /// <summary>
     /// Primary key for SalesTaxRate records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesTerritory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesTerritory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Sales territory lookup table.
 /// </summary>
-public partial class SalesTerritory
-{
+public partial record SalesTerritory{
     /// <summary>
     /// Primary key for SalesTerritory records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesTerritoryHistory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesTerritoryHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Sales representative transfers to other sales territories.
 /// </summary>
-public partial class SalesTerritoryHistory
-{
+public partial record SalesTerritoryHistory{
     /// <summary>
     /// Primary key. The sales rep.  Foreign key to SalesPerson.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ScrapReason.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ScrapReason.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Manufacturing failure reasons lookup table.
 /// </summary>
-public partial class ScrapReason
-{
+public partial record ScrapReason{
     /// <summary>
     /// Primary key for ScrapReason records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Shift.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Shift.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Work shift lookup table.
 /// </summary>
-public partial class Shift
-{
+public partial record Shift{
     /// <summary>
     /// Primary key for Shift records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ShipMethod.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ShipMethod.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Shipping company lookup table.
 /// </summary>
-public partial class ShipMethod
-{
+public partial record ShipMethod{
     /// <summary>
     /// Primary key for ShipMethod records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ShoppingCartItem.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ShoppingCartItem.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Contains online customer orders until the order is submitted or cancelled.
 /// </summary>
-public partial class ShoppingCartItem
-{
+public partial record ShoppingCartItem{
     /// <summary>
     /// Primary key for ShoppingCartItem records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SpecialOffer.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SpecialOffer.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Sale discounts lookup table.
 /// </summary>
-public partial class SpecialOffer
-{
+public partial record SpecialOffer{
     /// <summary>
     /// Primary key for SpecialOffer records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SpecialOfferProduct.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SpecialOfferProduct.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Cross-reference table mapping products to special offer discounts.
 /// </summary>
-public partial class SpecialOfferProduct
-{
+public partial record SpecialOfferProduct{
     /// <summary>
     /// Primary key for SpecialOfferProduct records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/StateProvince.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/StateProvince.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// State and province lookup table.
 /// </summary>
-public partial class StateProvince
-{
+public partial record StateProvince{
     /// <summary>
     /// Primary key for StateProvince records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Store.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Store.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Customers (resellers) of Adventure Works products.
 /// </summary>
-public partial class Store
-{
+public partial record Store{
     /// <summary>
     /// Primary key. Foreign key to Customer.BusinessEntityID.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/TransactionHistory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/TransactionHistory.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Record of each purchase order, sales order, or work order transaction year to date.
 /// </summary>
-public partial class TransactionHistory
-{
+public partial record TransactionHistory{
     /// <summary>
     /// Primary key for TransactionHistory records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/TransactionHistoryArchive.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/TransactionHistoryArchive.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Transactions for previous years.
 /// </summary>
-public partial class TransactionHistoryArchive
-{
+public partial record TransactionHistoryArchive{
     /// <summary>
     /// Primary key for TransactionHistoryArchive records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/UnitMeasure.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/UnitMeasure.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Unit of measure lookup table.
 /// </summary>
-public partial class UnitMeasure
-{
+public partial record UnitMeasure{
     /// <summary>
     /// Primary key.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VAdditionalContactInfo.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VAdditionalContactInfo.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VAdditionalContactInfo
-{
+public partial record VAdditionalContactInfo{
     public int BusinessEntityId { get; set; }
 
     public string FirstName { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VEmployee.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VEmployee.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VEmployee
-{
+public partial record VEmployee{
     public int BusinessEntityId { get; set; }
 
     public string Title { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VEmployeeDepartment.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VEmployeeDepartment.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VEmployeeDepartment
-{
+public partial record VEmployeeDepartment{
     public int BusinessEntityId { get; set; }
 
     public string Title { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VEmployeeDepartmentHistory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VEmployeeDepartmentHistory.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VEmployeeDepartmentHistory
-{
+public partial record VEmployeeDepartmentHistory{
     public int BusinessEntityId { get; set; }
 
     public string Title { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VIndividualCustomer.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VIndividualCustomer.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VIndividualCustomer
-{
+public partial record VIndividualCustomer{
     public int BusinessEntityId { get; set; }
 
     public string Title { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VJobCandidate.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VJobCandidate.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VJobCandidate
-{
+public partial record VJobCandidate{
     public int JobCandidateId { get; set; }
 
     public int? BusinessEntityId { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VJobCandidateEducation.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VJobCandidateEducation.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VJobCandidateEducation
-{
+public partial record VJobCandidateEducation{
     public int JobCandidateId { get; set; }
 
     public string EduLevel { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VJobCandidateEmployment.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VJobCandidateEmployment.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VJobCandidateEmployment
-{
+public partial record VJobCandidateEmployment{
     public int JobCandidateId { get; set; }
 
     public DateTime? EmpStartDate { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VPersonDemographic.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VPersonDemographic.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VPersonDemographic
-{
+public partial record VPersonDemographic{
     public int BusinessEntityId { get; set; }
 
     public decimal? TotalPurchaseYtd { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VProductAndDescription.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VProductAndDescription.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VProductAndDescription
-{
+public partial record VProductAndDescription{
     public int ProductId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VProductModelCatalogDescription.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VProductModelCatalogDescription.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VProductModelCatalogDescription
-{
+public partial record VProductModelCatalogDescription{
     public int ProductModelId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VProductModelInstruction.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VProductModelInstruction.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VProductModelInstruction
-{
+public partial record VProductModelInstruction{
     public int ProductModelId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VSalesPerson.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VSalesPerson.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VSalesPerson
-{
+public partial record VSalesPerson{
     public int BusinessEntityId { get; set; }
 
     public string Title { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VSalesPersonSalesByFiscalYear.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VSalesPersonSalesByFiscalYear.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VSalesPersonSalesByFiscalYear
-{
+public partial record VSalesPersonSalesByFiscalYear{
     public int? SalesPersonId { get; set; }
 
     public string FullName { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VStateProvinceCountryRegion.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VStateProvinceCountryRegion.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VStateProvinceCountryRegion
-{
+public partial record VStateProvinceCountryRegion{
     public int StateProvinceId { get; set; }
 
     public string StateProvinceCode { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VStoreWithAddress.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VStoreWithAddress.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VStoreWithAddress
-{
+public partial record VStoreWithAddress{
     public int BusinessEntityId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VStoreWithContact.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VStoreWithContact.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VStoreWithContact
-{
+public partial record VStoreWithContact{
     public int BusinessEntityId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VStoreWithDemographic.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VStoreWithDemographic.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VStoreWithDemographic
-{
+public partial record VStoreWithDemographic{
     public int BusinessEntityId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VVendorWithAddress.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VVendorWithAddress.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VVendorWithAddress
-{
+public partial record VVendorWithAddress{
     public int BusinessEntityId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VVendorWithContact.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VVendorWithContact.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace AdventureWorks.Models;
 
-public partial class VVendorWithContact
-{
+public partial record VVendorWithContact{
     public int BusinessEntityId { get; set; }
 
     public string Name { get; set; }

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Vendor.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Vendor.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Companies from whom Adventure Works Cycles purchases parts or other goods.
 /// </summary>
-public partial class Vendor
-{
+public partial record Vendor{
     /// <summary>
     /// Primary key for Vendor records.  Foreign key to BusinessEntity.BusinessEntityID
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/WorkOrder.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/WorkOrder.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Manufacturing work orders.
 /// </summary>
-public partial class WorkOrder
-{
+public partial record WorkOrder{
     /// <summary>
     /// Primary key for WorkOrder records.
     /// </summary>

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/WorkOrderRouting.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/WorkOrderRouting.cs
@@ -6,8 +6,7 @@ namespace AdventureWorks.Models;
 /// <summary>
 /// Work order details.
 /// </summary>
-public partial class WorkOrderRouting
-{
+public partial record WorkOrderRouting{
     /// <summary>
     /// Primary key. Foreign key to WorkOrder.WorkOrderID.
     /// </summary>

--- a/tests/Wolfgang.DbContextBuilder-Core-EF10.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF10.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF10.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF10.csproj
@@ -29,96 +29,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Address.cs" Link="Models\Generated\Address.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\AddressType.cs" Link="Models\Generated\AddressType.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\AdventureWorksDbContext.cs" Link="Models\Generated\AdventureWorksDbContext.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\AwbuildVersion.cs" Link="Models\Generated\AwbuildVersion.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\BillOfMaterial.cs" Link="Models\Generated\BillOfMaterial.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\BusinessEntity.cs" Link="Models\Generated\BusinessEntity.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\BusinessEntityAddress.cs" Link="Models\Generated\BusinessEntityAddress.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\BusinessEntityContact.cs" Link="Models\Generated\BusinessEntityContact.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ContactType.cs" Link="Models\Generated\ContactType.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\CountryRegion.cs" Link="Models\Generated\CountryRegion.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\CountryRegionCurrency.cs" Link="Models\Generated\CountryRegionCurrency.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\CreditCard.cs" Link="Models\Generated\CreditCard.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Culture.cs" Link="Models\Generated\Culture.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Currency.cs" Link="Models\Generated\Currency.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\CurrencyRate.cs" Link="Models\Generated\CurrencyRate.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Customer.cs" Link="Models\Generated\Customer.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\DatabaseLog.cs" Link="Models\Generated\DatabaseLog.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Department.cs" Link="Models\Generated\Department.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\EmailAddress.cs" Link="Models\Generated\EmailAddress.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Employee.cs" Link="Models\Generated\Employee.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\EmployeeDepartmentHistory.cs" Link="Models\Generated\EmployeeDepartmentHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\EmployeePayHistory.cs" Link="Models\Generated\EmployeePayHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ErrorLog.cs" Link="Models\Generated\ErrorLog.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Illustration.cs" Link="Models\Generated\Illustration.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\JobCandidate.cs" Link="Models\Generated\JobCandidate.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Location.cs" Link="Models\Generated\Location.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Password.cs" Link="Models\Generated\Password.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Person.cs" Link="Models\Generated\Person.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\PersonCreditCard.cs" Link="Models\Generated\PersonCreditCard.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\PersonPhone.cs" Link="Models\Generated\PersonPhone.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\PhoneNumberType.cs" Link="Models\Generated\PhoneNumberType.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Product.cs" Link="Models\Generated\Product.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductCategory.cs" Link="Models\Generated\ProductCategory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductCostHistory.cs" Link="Models\Generated\ProductCostHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductDescription.cs" Link="Models\Generated\ProductDescription.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductInventory.cs" Link="Models\Generated\ProductInventory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductListPriceHistory.cs" Link="Models\Generated\ProductListPriceHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductModel.cs" Link="Models\Generated\ProductModel.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductModelIllustration.cs" Link="Models\Generated\ProductModelIllustration.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductModelProductDescriptionCulture.cs" Link="Models\Generated\ProductModelProductDescriptionCulture.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductPhoto.cs" Link="Models\Generated\ProductPhoto.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductProductPhoto.cs" Link="Models\Generated\ProductProductPhoto.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductReview.cs" Link="Models\Generated\ProductReview.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductSubcategory.cs" Link="Models\Generated\ProductSubcategory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductVendor.cs" Link="Models\Generated\ProductVendor.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\PurchaseOrderDetail.cs" Link="Models\Generated\PurchaseOrderDetail.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\PurchaseOrderHeader.cs" Link="Models\Generated\PurchaseOrderHeader.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesOrderDetail.cs" Link="Models\Generated\SalesOrderDetail.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesOrderHeader.cs" Link="Models\Generated\SalesOrderHeader.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesOrderHeaderSalesReason.cs" Link="Models\Generated\SalesOrderHeaderSalesReason.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesPerson.cs" Link="Models\Generated\SalesPerson.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesPersonQuotaHistory.cs" Link="Models\Generated\SalesPersonQuotaHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesReason.cs" Link="Models\Generated\SalesReason.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesTaxRate.cs" Link="Models\Generated\SalesTaxRate.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesTerritory.cs" Link="Models\Generated\SalesTerritory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesTerritoryHistory.cs" Link="Models\Generated\SalesTerritoryHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ScrapReason.cs" Link="Models\Generated\ScrapReason.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Shift.cs" Link="Models\Generated\Shift.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ShipMethod.cs" Link="Models\Generated\ShipMethod.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ShoppingCartItem.cs" Link="Models\Generated\ShoppingCartItem.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SpecialOffer.cs" Link="Models\Generated\SpecialOffer.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SpecialOfferProduct.cs" Link="Models\Generated\SpecialOfferProduct.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\StateProvince.cs" Link="Models\Generated\StateProvince.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Store.cs" Link="Models\Generated\Store.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\TransactionHistory.cs" Link="Models\Generated\TransactionHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\TransactionHistoryArchive.cs" Link="Models\Generated\TransactionHistoryArchive.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\UnitMeasure.cs" Link="Models\Generated\UnitMeasure.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VAdditionalContactInfo.cs" Link="Models\Generated\VAdditionalContactInfo.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VEmployee.cs" Link="Models\Generated\VEmployee.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VEmployeeDepartment.cs" Link="Models\Generated\VEmployeeDepartment.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VEmployeeDepartmentHistory.cs" Link="Models\Generated\VEmployeeDepartmentHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Vendor.cs" Link="Models\Generated\Vendor.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VIndividualCustomer.cs" Link="Models\Generated\VIndividualCustomer.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VJobCandidate.cs" Link="Models\Generated\VJobCandidate.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VJobCandidateEducation.cs" Link="Models\Generated\VJobCandidateEducation.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VJobCandidateEmployment.cs" Link="Models\Generated\VJobCandidateEmployment.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VPersonDemographic.cs" Link="Models\Generated\VPersonDemographic.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VProductAndDescription.cs" Link="Models\Generated\VProductAndDescription.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VProductModelCatalogDescription.cs" Link="Models\Generated\VProductModelCatalogDescription.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VProductModelInstruction.cs" Link="Models\Generated\VProductModelInstruction.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VSalesPerson.cs" Link="Models\Generated\VSalesPerson.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VSalesPersonSalesByFiscalYear.cs" Link="Models\Generated\VSalesPersonSalesByFiscalYear.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VStateProvinceCountryRegion.cs" Link="Models\Generated\VStateProvinceCountryRegion.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VStoreWithAddress.cs" Link="Models\Generated\VStoreWithAddress.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VStoreWithContact.cs" Link="Models\Generated\VStoreWithContact.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VStoreWithDemographic.cs" Link="Models\Generated\VStoreWithDemographic.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VVendorWithAddress.cs" Link="Models\Generated\VVendorWithAddress.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VVendorWithContact.cs" Link="Models\Generated\VVendorWithContact.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\WorkOrder.cs" Link="Models\Generated\WorkOrder.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\WorkOrderRouting.cs" Link="Models\Generated\WorkOrderRouting.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\AutoFixtureRandomEntityCreatorTests.cs" Link="AutoFixtureRandomEntityCreatorTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\DbContextBuilderTestsBase.cs" Link="DbContextBuilderTestsBase.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\ICreateRandomEntitiesTestsBase.cs" Link="ICreateRandomEntitiesTestsBase.cs" />
@@ -161,6 +71,7 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\..\src\Wolfgang.DbContextBuilder-Core-EF10\Wolfgang.DbContextBuilder-Core-EF10.csproj" />
+	  <ProjectReference Include="..\..\extra-projects\AdventureWorks-EF10\AdventureWorks-EF10.csproj" />
 	</ItemGroup>
 
 

--- a/tests/Wolfgang.DbContextBuilder-Core-EF10.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF10.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF10.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF10.csproj
@@ -66,10 +66,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Folder Include="Models\Generated\" />
-	</ItemGroup>
-
-	<ItemGroup>
 	  <ProjectReference Include="..\..\src\Wolfgang.DbContextBuilder-Core-EF10\Wolfgang.DbContextBuilder-Core-EF10.csproj" />
 	  <ProjectReference Include="..\..\extra-projects\AdventureWorks-EF10\AdventureWorks-EF10.csproj" />
 	</ItemGroup>

--- a/tests/Wolfgang.DbContextBuilder-Core-EF8.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF8.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF8.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF8.csproj
@@ -66,10 +66,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Folder Include="Models\Generated\" />
-	</ItemGroup>
-
-	<ItemGroup>
 	  <ProjectReference Include="..\..\src\Wolfgang.DbContextBuilder-Core-EF8\Wolfgang.DbContextBuilder-Core-EF8.csproj" />
 	  <ProjectReference Include="..\..\extra-projects\AdventureWorks-EF8\AdventureWorks-EF8.csproj" />
 	</ItemGroup>

--- a/tests/Wolfgang.DbContextBuilder-Core-EF8.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF8.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF8.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF8.csproj
@@ -29,96 +29,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Address.cs" Link="Models\Generated\Address.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\AddressType.cs" Link="Models\Generated\AddressType.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\AdventureWorksDbContext.cs" Link="Models\Generated\AdventureWorksDbContext.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\AwbuildVersion.cs" Link="Models\Generated\AwbuildVersion.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\BillOfMaterial.cs" Link="Models\Generated\BillOfMaterial.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\BusinessEntity.cs" Link="Models\Generated\BusinessEntity.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\BusinessEntityAddress.cs" Link="Models\Generated\BusinessEntityAddress.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\BusinessEntityContact.cs" Link="Models\Generated\BusinessEntityContact.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ContactType.cs" Link="Models\Generated\ContactType.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\CountryRegion.cs" Link="Models\Generated\CountryRegion.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\CountryRegionCurrency.cs" Link="Models\Generated\CountryRegionCurrency.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\CreditCard.cs" Link="Models\Generated\CreditCard.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Culture.cs" Link="Models\Generated\Culture.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Currency.cs" Link="Models\Generated\Currency.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\CurrencyRate.cs" Link="Models\Generated\CurrencyRate.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Customer.cs" Link="Models\Generated\Customer.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\DatabaseLog.cs" Link="Models\Generated\DatabaseLog.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Department.cs" Link="Models\Generated\Department.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\EmailAddress.cs" Link="Models\Generated\EmailAddress.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Employee.cs" Link="Models\Generated\Employee.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\EmployeeDepartmentHistory.cs" Link="Models\Generated\EmployeeDepartmentHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\EmployeePayHistory.cs" Link="Models\Generated\EmployeePayHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ErrorLog.cs" Link="Models\Generated\ErrorLog.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Illustration.cs" Link="Models\Generated\Illustration.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\JobCandidate.cs" Link="Models\Generated\JobCandidate.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Location.cs" Link="Models\Generated\Location.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Password.cs" Link="Models\Generated\Password.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Person.cs" Link="Models\Generated\Person.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\PersonCreditCard.cs" Link="Models\Generated\PersonCreditCard.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\PersonPhone.cs" Link="Models\Generated\PersonPhone.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\PhoneNumberType.cs" Link="Models\Generated\PhoneNumberType.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Product.cs" Link="Models\Generated\Product.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductCategory.cs" Link="Models\Generated\ProductCategory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductCostHistory.cs" Link="Models\Generated\ProductCostHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductDescription.cs" Link="Models\Generated\ProductDescription.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductInventory.cs" Link="Models\Generated\ProductInventory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductListPriceHistory.cs" Link="Models\Generated\ProductListPriceHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductModel.cs" Link="Models\Generated\ProductModel.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductModelIllustration.cs" Link="Models\Generated\ProductModelIllustration.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductModelProductDescriptionCulture.cs" Link="Models\Generated\ProductModelProductDescriptionCulture.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductPhoto.cs" Link="Models\Generated\ProductPhoto.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductProductPhoto.cs" Link="Models\Generated\ProductProductPhoto.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductReview.cs" Link="Models\Generated\ProductReview.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductSubcategory.cs" Link="Models\Generated\ProductSubcategory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductVendor.cs" Link="Models\Generated\ProductVendor.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\PurchaseOrderDetail.cs" Link="Models\Generated\PurchaseOrderDetail.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\PurchaseOrderHeader.cs" Link="Models\Generated\PurchaseOrderHeader.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesOrderDetail.cs" Link="Models\Generated\SalesOrderDetail.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesOrderHeader.cs" Link="Models\Generated\SalesOrderHeader.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesOrderHeaderSalesReason.cs" Link="Models\Generated\SalesOrderHeaderSalesReason.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesPerson.cs" Link="Models\Generated\SalesPerson.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesPersonQuotaHistory.cs" Link="Models\Generated\SalesPersonQuotaHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesReason.cs" Link="Models\Generated\SalesReason.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesTaxRate.cs" Link="Models\Generated\SalesTaxRate.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesTerritory.cs" Link="Models\Generated\SalesTerritory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesTerritoryHistory.cs" Link="Models\Generated\SalesTerritoryHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ScrapReason.cs" Link="Models\Generated\ScrapReason.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Shift.cs" Link="Models\Generated\Shift.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ShipMethod.cs" Link="Models\Generated\ShipMethod.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ShoppingCartItem.cs" Link="Models\Generated\ShoppingCartItem.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SpecialOffer.cs" Link="Models\Generated\SpecialOffer.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SpecialOfferProduct.cs" Link="Models\Generated\SpecialOfferProduct.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\StateProvince.cs" Link="Models\Generated\StateProvince.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Store.cs" Link="Models\Generated\Store.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\TransactionHistory.cs" Link="Models\Generated\TransactionHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\TransactionHistoryArchive.cs" Link="Models\Generated\TransactionHistoryArchive.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\UnitMeasure.cs" Link="Models\Generated\UnitMeasure.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VAdditionalContactInfo.cs" Link="Models\Generated\VAdditionalContactInfo.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VEmployee.cs" Link="Models\Generated\VEmployee.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VEmployeeDepartment.cs" Link="Models\Generated\VEmployeeDepartment.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VEmployeeDepartmentHistory.cs" Link="Models\Generated\VEmployeeDepartmentHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Vendor.cs" Link="Models\Generated\Vendor.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VIndividualCustomer.cs" Link="Models\Generated\VIndividualCustomer.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VJobCandidate.cs" Link="Models\Generated\VJobCandidate.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VJobCandidateEducation.cs" Link="Models\Generated\VJobCandidateEducation.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VJobCandidateEmployment.cs" Link="Models\Generated\VJobCandidateEmployment.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VPersonDemographic.cs" Link="Models\Generated\VPersonDemographic.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VProductAndDescription.cs" Link="Models\Generated\VProductAndDescription.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VProductModelCatalogDescription.cs" Link="Models\Generated\VProductModelCatalogDescription.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VProductModelInstruction.cs" Link="Models\Generated\VProductModelInstruction.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VSalesPerson.cs" Link="Models\Generated\VSalesPerson.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VSalesPersonSalesByFiscalYear.cs" Link="Models\Generated\VSalesPersonSalesByFiscalYear.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VStateProvinceCountryRegion.cs" Link="Models\Generated\VStateProvinceCountryRegion.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VStoreWithAddress.cs" Link="Models\Generated\VStoreWithAddress.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VStoreWithContact.cs" Link="Models\Generated\VStoreWithContact.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VStoreWithDemographic.cs" Link="Models\Generated\VStoreWithDemographic.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VVendorWithAddress.cs" Link="Models\Generated\VVendorWithAddress.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VVendorWithContact.cs" Link="Models\Generated\VVendorWithContact.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\WorkOrder.cs" Link="Models\Generated\WorkOrder.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\WorkOrderRouting.cs" Link="Models\Generated\WorkOrderRouting.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\AutoFixtureRandomEntityCreatorTests.cs" Link="AutoFixtureRandomEntityCreatorTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\DbContextBuilderTestsBase.cs" Link="DbContextBuilderTestsBase.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\ICreateRandomEntitiesTestsBase.cs" Link="ICreateRandomEntitiesTestsBase.cs" />
@@ -161,6 +71,7 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\..\src\Wolfgang.DbContextBuilder-Core-EF8\Wolfgang.DbContextBuilder-Core-EF8.csproj" />
+	  <ProjectReference Include="..\..\extra-projects\AdventureWorks-EF8\AdventureWorks-EF8.csproj" />
 	</ItemGroup>
 
 

--- a/tests/Wolfgang.DbContextBuilder-Core-EF9.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF9.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF9.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF9.csproj
@@ -66,10 +66,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Folder Include="Models\Generated\" />
-	</ItemGroup>
-
-	<ItemGroup>
 	  <ProjectReference Include="..\..\src\Wolfgang.DbContextBuilder-Core-EF9\Wolfgang.DbContextBuilder-Core-EF9.csproj" />
 	  <ProjectReference Include="..\..\extra-projects\AdventureWorks-EF9\AdventureWorks-EF9.csproj" />
 	</ItemGroup>

--- a/tests/Wolfgang.DbContextBuilder-Core-EF9.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF9.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF9.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF9.csproj
@@ -29,96 +29,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Address.cs" Link="Models\Generated\Address.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\AddressType.cs" Link="Models\Generated\AddressType.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\AdventureWorksDbContext.cs" Link="Models\Generated\AdventureWorksDbContext.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\AwbuildVersion.cs" Link="Models\Generated\AwbuildVersion.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\BillOfMaterial.cs" Link="Models\Generated\BillOfMaterial.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\BusinessEntity.cs" Link="Models\Generated\BusinessEntity.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\BusinessEntityAddress.cs" Link="Models\Generated\BusinessEntityAddress.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\BusinessEntityContact.cs" Link="Models\Generated\BusinessEntityContact.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ContactType.cs" Link="Models\Generated\ContactType.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\CountryRegion.cs" Link="Models\Generated\CountryRegion.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\CountryRegionCurrency.cs" Link="Models\Generated\CountryRegionCurrency.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\CreditCard.cs" Link="Models\Generated\CreditCard.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Culture.cs" Link="Models\Generated\Culture.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Currency.cs" Link="Models\Generated\Currency.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\CurrencyRate.cs" Link="Models\Generated\CurrencyRate.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Customer.cs" Link="Models\Generated\Customer.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\DatabaseLog.cs" Link="Models\Generated\DatabaseLog.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Department.cs" Link="Models\Generated\Department.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\EmailAddress.cs" Link="Models\Generated\EmailAddress.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Employee.cs" Link="Models\Generated\Employee.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\EmployeeDepartmentHistory.cs" Link="Models\Generated\EmployeeDepartmentHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\EmployeePayHistory.cs" Link="Models\Generated\EmployeePayHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ErrorLog.cs" Link="Models\Generated\ErrorLog.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Illustration.cs" Link="Models\Generated\Illustration.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\JobCandidate.cs" Link="Models\Generated\JobCandidate.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Location.cs" Link="Models\Generated\Location.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Password.cs" Link="Models\Generated\Password.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Person.cs" Link="Models\Generated\Person.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\PersonCreditCard.cs" Link="Models\Generated\PersonCreditCard.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\PersonPhone.cs" Link="Models\Generated\PersonPhone.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\PhoneNumberType.cs" Link="Models\Generated\PhoneNumberType.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Product.cs" Link="Models\Generated\Product.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductCategory.cs" Link="Models\Generated\ProductCategory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductCostHistory.cs" Link="Models\Generated\ProductCostHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductDescription.cs" Link="Models\Generated\ProductDescription.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductInventory.cs" Link="Models\Generated\ProductInventory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductListPriceHistory.cs" Link="Models\Generated\ProductListPriceHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductModel.cs" Link="Models\Generated\ProductModel.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductModelIllustration.cs" Link="Models\Generated\ProductModelIllustration.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductModelProductDescriptionCulture.cs" Link="Models\Generated\ProductModelProductDescriptionCulture.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductPhoto.cs" Link="Models\Generated\ProductPhoto.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductProductPhoto.cs" Link="Models\Generated\ProductProductPhoto.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductReview.cs" Link="Models\Generated\ProductReview.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductSubcategory.cs" Link="Models\Generated\ProductSubcategory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ProductVendor.cs" Link="Models\Generated\ProductVendor.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\PurchaseOrderDetail.cs" Link="Models\Generated\PurchaseOrderDetail.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\PurchaseOrderHeader.cs" Link="Models\Generated\PurchaseOrderHeader.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesOrderDetail.cs" Link="Models\Generated\SalesOrderDetail.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesOrderHeader.cs" Link="Models\Generated\SalesOrderHeader.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesOrderHeaderSalesReason.cs" Link="Models\Generated\SalesOrderHeaderSalesReason.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesPerson.cs" Link="Models\Generated\SalesPerson.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesPersonQuotaHistory.cs" Link="Models\Generated\SalesPersonQuotaHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesReason.cs" Link="Models\Generated\SalesReason.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesTaxRate.cs" Link="Models\Generated\SalesTaxRate.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesTerritory.cs" Link="Models\Generated\SalesTerritory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SalesTerritoryHistory.cs" Link="Models\Generated\SalesTerritoryHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ScrapReason.cs" Link="Models\Generated\ScrapReason.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Shift.cs" Link="Models\Generated\Shift.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ShipMethod.cs" Link="Models\Generated\ShipMethod.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\ShoppingCartItem.cs" Link="Models\Generated\ShoppingCartItem.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SpecialOffer.cs" Link="Models\Generated\SpecialOffer.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\SpecialOfferProduct.cs" Link="Models\Generated\SpecialOfferProduct.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\StateProvince.cs" Link="Models\Generated\StateProvince.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Store.cs" Link="Models\Generated\Store.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\TransactionHistory.cs" Link="Models\Generated\TransactionHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\TransactionHistoryArchive.cs" Link="Models\Generated\TransactionHistoryArchive.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\UnitMeasure.cs" Link="Models\Generated\UnitMeasure.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VAdditionalContactInfo.cs" Link="Models\Generated\VAdditionalContactInfo.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VEmployee.cs" Link="Models\Generated\VEmployee.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VEmployeeDepartment.cs" Link="Models\Generated\VEmployeeDepartment.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VEmployeeDepartmentHistory.cs" Link="Models\Generated\VEmployeeDepartmentHistory.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\Vendor.cs" Link="Models\Generated\Vendor.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VIndividualCustomer.cs" Link="Models\Generated\VIndividualCustomer.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VJobCandidate.cs" Link="Models\Generated\VJobCandidate.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VJobCandidateEducation.cs" Link="Models\Generated\VJobCandidateEducation.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VJobCandidateEmployment.cs" Link="Models\Generated\VJobCandidateEmployment.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VPersonDemographic.cs" Link="Models\Generated\VPersonDemographic.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VProductAndDescription.cs" Link="Models\Generated\VProductAndDescription.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VProductModelCatalogDescription.cs" Link="Models\Generated\VProductModelCatalogDescription.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VProductModelInstruction.cs" Link="Models\Generated\VProductModelInstruction.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VSalesPerson.cs" Link="Models\Generated\VSalesPerson.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VSalesPersonSalesByFiscalYear.cs" Link="Models\Generated\VSalesPersonSalesByFiscalYear.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VStateProvinceCountryRegion.cs" Link="Models\Generated\VStateProvinceCountryRegion.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VStoreWithAddress.cs" Link="Models\Generated\VStoreWithAddress.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VStoreWithContact.cs" Link="Models\Generated\VStoreWithContact.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VStoreWithDemographic.cs" Link="Models\Generated\VStoreWithDemographic.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VVendorWithAddress.cs" Link="Models\Generated\VVendorWithAddress.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\VVendorWithContact.cs" Link="Models\Generated\VVendorWithContact.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\WorkOrder.cs" Link="Models\Generated\WorkOrder.cs" />
-		<Compile Include="..\..\extra-projects\AdventureWorks-EF7\Models\Generated\WorkOrderRouting.cs" Link="Models\Generated\WorkOrderRouting.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\AutoFixtureRandomEntityCreatorTests.cs" Link="AutoFixtureRandomEntityCreatorTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\DbContextBuilderTestsBase.cs" Link="DbContextBuilderTestsBase.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\ICreateRandomEntitiesTestsBase.cs" Link="ICreateRandomEntitiesTestsBase.cs" />
@@ -161,6 +71,7 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\..\src\Wolfgang.DbContextBuilder-Core-EF9\Wolfgang.DbContextBuilder-Core-EF9.csproj" />
+	  <ProjectReference Include="..\..\extra-projects\AdventureWorks-EF9\AdventureWorks-EF9.csproj" />
 	</ItemGroup>
 
 


### PR DESCRIPTION
## Summary

Closes the second half of #41/#42/#43. PR #262 (parent) adds the
EF8/9/10 scaffolds. This PR makes the test projects actually use them.

**Result: 1,266 tests pass** across 3 EF versions × per-EF target
framework matrix — every EF library is now tested against the
AdventureWorks model scaffolded by **its own EF version's `dotnet ef`
CLI**, exactly as #41/#42/#43 asked.

## Stacks on top of #262

This PR's diff is meaningful only after #262 lands first (it depends
on `extra-projects/AdventureWorks-EF8/9/10/` existing). Set base
branch to `stack/scaffold-ef8-ef9-ef10` so GitHub shows the right
diff.

## Three transforms applied to each AdventureWorks-EFN

1. **Convert `class` → `record`** in all entity files (DbContext
   excluded). `DbContextBuilderTestsBase.cs` lines 447, 721 use
   `expectedCountry with { }` and `Select(c => c with { })` —
   `with`-expression syntax is record-only. EF7's scaffold was
   already records; EF8+ `dotnet ef` CLI emits `class` by default.

2. **Strip `tb.HasTrigger(...)`** lines from `AdventureWorksDbContext.cs`
   (10 per project). Modern EF `dotnet ef` discovers SQL Server
   triggers; `SqliteForMsSqlServerModelCustomizer.OverrideTableRenaming`
   flattens schema-qualified table names (`HumanResources.Employee` →
   `HumanResources_Employee`) but the trigger annotation still
   references the original schema-qualified name, causing
   `SqliteModelValidator` to throw at `EnsureCreatedAsync` time. EF7
   scaffold didn't discover triggers.

3. **Switch each EFN test csproj from `<Compile Include>` to
   `<ProjectReference>`** on the matching `AdventureWorks-EFN`
   project. Sidesteps the SQL-Server-specific extension issue
   (`HasDefaultValueSql`, `IsClustered`) — the AdventureWorks project
   compiles in its own assembly with its own SqlServer package
   context. The test csproj consumes the resulting `.dll` via
   assembly reference, getting all the AdventureWorks types without
   needing to compile the scaffold source in the test context.

## Verified

Per-target-framework test runs (no skipped, no failed):

| Test csproj | net8.0 | net9.0 | net10.0 |
|---|---|---|---|
| `…-EF8.Tests.Unit-EF8.csproj` | ✅ 211/211 | ✅ 211/211 | ✅ 211/211 |
| `…-EF9.Tests.Unit-EF9.csproj` | n/a | ✅ 211/211 | ✅ 211/211 |
| `…-EF10.Tests.Unit-EF10.csproj` | n/a | n/a | ✅ 211/211 |

**Total: 1,266 test cases pass** across the three EF versions.

## Closes

- **#41** — Scaffold EF 8 + EF 8 library tested against EF 8 scaffold
- **#42** — Scaffold EF 9 + EF 9 library tested against EF 9 scaffold
- **#43** — Scaffold EF 10 + EF 10 library tested against EF 10 scaffold

## Out of scope (still pending)

- **#235** (test warning debt) — the new EFN test projects no longer
  trigger MA0051/CS8669 in their compile path (the AdventureWorks-EFN
  scaffolds compile in their own assemblies, isolated from the test
  csproj's TWEA-Release context). But the default
  `Wolfgang.DbContextBuilder-Core.Tests.Unit` project (no EF suffix)
  still source-links the EF6 AdventureWorks scaffold and the
  `tests/Directory.Build.props` C1 deviation (`TreatWarningsAsErrors=false`)
  is still in place for that reason. Closing #235 fully requires
  re-scaffolding AdventureWorks-EF6 or switching that test project
  to ProjectReference too — a separate effort.