### PR TITLE
Add fluent DbSet assertions for DbContextBuilder tests (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New `Wolfgang.DbContextBuilderCore.Assertions` namespace providing a small fluent,
+  chainable assertion surface for verifying the state of a `DbSet<T>` in tests:
+  `HaveCount`, `BeEmpty`, `NotBeEmpty`, `Contain`, `NotContain`, `AllSatisfy`. Obtain
+  the assertion chain via `dbSet.Should()` or `queryable.Should()`. Failures throw
+  `DbContextAssertionException` with an entity-typed message. (#106)
+
 ### Changed
 
 ### Deprecated

--- a/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
@@ -43,6 +43,9 @@
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteDbContextCreator.cs" Link="SqliteDbContextCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteForMsSqlServerModelCustomizer.cs" Link="SqliteForMsSqlServerModelCustomizer.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteModelCustomizer.cs" Link="SqliteModelCustomizer.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assertions\DbContextAssertionException.cs" Link="Assertions\DbContextAssertionException.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assertions\DbContextAssertionsExtensions.cs" Link="Assertions\DbContextAssertionsExtensions.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assertions\DbSetAssertions.cs" Link="Assertions\DbSetAssertions.cs" />
 	 </ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="AutoFixture" Version="4.18.1" />

--- a/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
@@ -43,6 +43,9 @@
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteDbContextCreator.cs" Link="SqliteDbContextCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteForMsSqlServerModelCustomizer.cs" Link="SqliteForMsSqlServerModelCustomizer.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteModelCustomizer.cs" Link="SqliteModelCustomizer.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assertions\DbContextAssertionException.cs" Link="Assertions\DbContextAssertionException.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assertions\DbContextAssertionsExtensions.cs" Link="Assertions\DbContextAssertionsExtensions.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assertions\DbSetAssertions.cs" Link="Assertions\DbSetAssertions.cs" />
 	 </ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="AutoFixture" Version="4.18.1" />

--- a/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
@@ -43,6 +43,9 @@
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteDbContextCreator.cs" Link="SqliteDbContextCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteForMsSqlServerModelCustomizer.cs" Link="SqliteForMsSqlServerModelCustomizer.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteModelCustomizer.cs" Link="SqliteModelCustomizer.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assertions\DbContextAssertionException.cs" Link="Assertions\DbContextAssertionException.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assertions\DbContextAssertionsExtensions.cs" Link="Assertions\DbContextAssertionsExtensions.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assertions\DbSetAssertions.cs" Link="Assertions\DbSetAssertions.cs" />
 	 </ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="AutoFixture" Version="4.18.1" />

--- a/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
@@ -43,6 +43,9 @@
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteDbContextCreator.cs" Link="SqliteDbContextCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteForMsSqlServerModelCustomizer.cs" Link="SqliteForMsSqlServerModelCustomizer.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteModelCustomizer.cs" Link="SqliteModelCustomizer.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assertions\DbContextAssertionException.cs" Link="Assertions\DbContextAssertionException.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assertions\DbContextAssertionsExtensions.cs" Link="Assertions\DbContextAssertionsExtensions.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assertions\DbSetAssertions.cs" Link="Assertions\DbSetAssertions.cs" />
 	 </ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="AutoFixture" Version="4.18.1" />

--- a/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
@@ -43,6 +43,9 @@
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteDbContextCreator.cs" Link="SqliteDbContextCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteForMsSqlServerModelCustomizer.cs" Link="SqliteForMsSqlServerModelCustomizer.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteModelCustomizer.cs" Link="SqliteModelCustomizer.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assertions\DbContextAssertionException.cs" Link="Assertions\DbContextAssertionException.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assertions\DbContextAssertionsExtensions.cs" Link="Assertions\DbContextAssertionsExtensions.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assertions\DbSetAssertions.cs" Link="Assertions\DbSetAssertions.cs" />
 	 </ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="AutoFixture" Version="4.18.1" />

--- a/src/Wolfgang.DbContextBuilder-Core/Assertions/DbContextAssertionException.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/Assertions/DbContextAssertionException.cs
@@ -1,0 +1,21 @@
+namespace Wolfgang.DbContextBuilderCore.Assertions;
+
+/// <summary>
+/// Thrown when a <see cref="DbSetAssertions{TEntity}"/> assertion fails. Carries an
+/// EF-aware failure message that identifies the entity type and the specific check that
+/// did not pass.
+/// </summary>
+public class DbContextAssertionException : Exception
+{
+    /// <summary>Initializes a new instance with no message or inner exception.</summary>
+    public DbContextAssertionException() { }
+
+    /// <summary>Initializes a new instance with the specified message.</summary>
+    /// <param name="message">The failure message describing what assertion did not hold.</param>
+    public DbContextAssertionException(string message) : base(message) { }
+
+    /// <summary>Initializes a new instance with the specified message and inner exception.</summary>
+    /// <param name="message">The failure message describing what assertion did not hold.</param>
+    /// <param name="innerException">The exception that caused the assertion to fail.</param>
+    public DbContextAssertionException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/src/Wolfgang.DbContextBuilder-Core/Assertions/DbContextAssertionsExtensions.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/Assertions/DbContextAssertionsExtensions.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolfgang.DbContextBuilderCore.Assertions;
+
+/// <summary>
+/// Entry-point extensions that produce a <see cref="DbSetAssertions{TEntity}"/> from a
+/// <see cref="DbSet{TEntity}"/> or <see cref="IQueryable{TEntity}"/>. Intended to be
+/// imported via <c>using Wolfgang.DbContextBuilderCore.Assertions;</c> in test files so
+/// that <c>context.Set&lt;Product&gt;().Should()</c> resolves.
+/// </summary>
+public static class DbContextAssertionsExtensions
+{
+    /// <summary>
+    /// Begins a fluent assertion chain against the specified <see cref="DbSet{TEntity}"/>.
+    /// </summary>
+    /// <typeparam name="TEntity">The entity type tracked by the DbSet.</typeparam>
+    /// <param name="set">The DbSet to assert against.</param>
+    /// <returns>A <see cref="DbSetAssertions{TEntity}"/> instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="set"/> is null.</exception>
+    public static DbSetAssertions<TEntity> Should<TEntity>(this DbSet<TEntity> set)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(set);
+        return new DbSetAssertions<TEntity>(set);
+    }
+
+
+
+    /// <summary>
+    /// Begins a fluent assertion chain against an arbitrary <see cref="IQueryable{TEntity}"/>.
+    /// Useful for asserting against a filtered/projected query rather than a whole DbSet.
+    /// </summary>
+    /// <typeparam name="TEntity">The element type of the queryable.</typeparam>
+    /// <param name="query">The queryable to assert against.</param>
+    /// <returns>A <see cref="DbSetAssertions{TEntity}"/> instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="query"/> is null.</exception>
+    public static DbSetAssertions<TEntity> Should<TEntity>(this IQueryable<TEntity> query)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        return new DbSetAssertions<TEntity>(query);
+    }
+}

--- a/src/Wolfgang.DbContextBuilder-Core/Assertions/DbContextAssertionsExtensions.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/Assertions/DbContextAssertionsExtensions.cs
@@ -27,8 +27,10 @@ public static class DbContextAssertionsExtensions
 
 
     /// <summary>
-    /// Begins a fluent assertion chain against an arbitrary <see cref="IQueryable{TEntity}"/>.
-    /// Useful for asserting against a filtered/projected query rather than a whole DbSet.
+    /// Begins a fluent assertion chain against a filtered <see cref="IQueryable{TEntity}"/>
+    /// derived from a DbSet — typically the result of <c>dbSet.Where(...)</c>. The
+    /// <typeparamref name="TEntity"/> constraint is <c>: class</c> because this surface is
+    /// intended for entity queries (not scalar or anonymous projections).
     /// </summary>
     /// <typeparam name="TEntity">The element type of the queryable.</typeparam>
     /// <param name="query">The queryable to assert against.</param>

--- a/src/Wolfgang.DbContextBuilder-Core/Assertions/DbSetAssertions.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/Assertions/DbSetAssertions.cs
@@ -4,11 +4,11 @@ using Microsoft.EntityFrameworkCore;
 namespace Wolfgang.DbContextBuilderCore.Assertions;
 
 /// <summary>
-/// Fluent, chainable assertions over a single <see cref="DbSet{TEntity}"/> for use in
-/// DbContextBuilder-backed tests. Each method runs the corresponding query asynchronously
-/// against the underlying <see cref="IQueryable{TEntity}"/>, throws
-/// <see cref="DbContextAssertionException"/> with an EF-aware message on failure, and
-/// returns <c>this</c> so the next assertion can be chained.
+/// Fluent, chainable assertions over an <see cref="IQueryable{TEntity}"/> — either a
+/// <see cref="DbSet{TEntity}"/> directly or a filtered query derived from one — for use
+/// in DbContextBuilder-backed tests. Each method runs the corresponding query
+/// asynchronously, throws <see cref="DbContextAssertionException"/> with an EF-aware
+/// message on failure, and returns <c>this</c> so the next assertion can be chained.
 /// </summary>
 /// <typeparam name="TEntity">The entity type tracked by the wrapped DbSet.</typeparam>
 /// <remarks>
@@ -60,9 +60,12 @@ public sealed class DbSetAssertions<TEntity>
     /// </exception>
     public async Task<DbSetAssertions<TEntity>> BeEmpty()
     {
-        var actual = await _query.CountAsync().ConfigureAwait(false);
-        if (actual != 0)
+        // AnyAsync short-circuits on the first row; only run the full Count on the
+        // failing path so the success case stays O(1).
+        var any = await _query.AnyAsync().ConfigureAwait(false);
+        if (any)
         {
+            var actual = await _query.CountAsync().ConfigureAwait(false);
             throw new DbContextAssertionException(
                 $"Expected DbSet<{typeof(TEntity).Name}> to be empty, but found {actual} entities.");
         }
@@ -135,12 +138,15 @@ public sealed class DbSetAssertions<TEntity>
     {
         ArgumentNullException.ThrowIfNull(predicate);
 
-        var matched = await _query.CountAsync(predicate).ConfigureAwait(false);
-        if (matched != 0)
+        // AnyAsync short-circuits on the first match; only run the full Count on the
+        // failing path so the success case stays O(1).
+        var matched = await _query.AnyAsync(predicate).ConfigureAwait(false);
+        if (matched)
         {
+            var count = await _query.CountAsync(predicate).ConfigureAwait(false);
             throw new DbContextAssertionException(
                 $"Expected DbSet<{typeof(TEntity).Name}> to contain NO entity matching ({predicate}), " +
-                $"but {matched} matching entities were found.");
+                $"but {count} matching entities were found.");
         }
 
         return this;

--- a/src/Wolfgang.DbContextBuilder-Core/Assertions/DbSetAssertions.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/Assertions/DbSetAssertions.cs
@@ -1,0 +1,183 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolfgang.DbContextBuilderCore.Assertions;
+
+/// <summary>
+/// Fluent, chainable assertions over a single <see cref="DbSet{TEntity}"/> for use in
+/// DbContextBuilder-backed tests. Each method runs the corresponding query asynchronously
+/// against the underlying <see cref="IQueryable{TEntity}"/>, throws
+/// <see cref="DbContextAssertionException"/> with an EF-aware message on failure, and
+/// returns <c>this</c> so the next assertion can be chained.
+/// </summary>
+/// <typeparam name="TEntity">The entity type tracked by the wrapped DbSet.</typeparam>
+/// <remarks>
+/// Obtain an instance via <c>DbContextAssertionsExtensions.Should</c> on a
+/// <see cref="DbSet{TEntity}"/> or <see cref="IQueryable{TEntity}"/>. The assertion
+/// methods are async because they translate to EF queries; <c>await</c> the final chain.
+/// </remarks>
+public sealed class DbSetAssertions<TEntity>
+    where TEntity : class
+{
+    private readonly IQueryable<TEntity> _query;
+
+    internal DbSetAssertions(IQueryable<TEntity> query)
+    {
+        _query = query;
+    }
+
+
+
+    /// <summary>
+    /// Asserts that the wrapped <see cref="DbSet{TEntity}"/> contains exactly <paramref name="expected"/>
+    /// entities.
+    /// </summary>
+    /// <param name="expected">The exact entity count expected.</param>
+    /// <returns>This assertions instance for chaining.</returns>
+    /// <exception cref="DbContextAssertionException">
+    /// The actual count differs from <paramref name="expected"/>.
+    /// </exception>
+    public async Task<DbSetAssertions<TEntity>> HaveCount(int expected)
+    {
+        var actual = await _query.CountAsync().ConfigureAwait(false);
+        if (actual != expected)
+        {
+            throw new DbContextAssertionException(
+                $"Expected DbSet<{typeof(TEntity).Name}> to have {expected} entities, but found {actual}.");
+        }
+
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Asserts that the wrapped <see cref="DbSet{TEntity}"/> contains no entities.
+    /// </summary>
+    /// <returns>This assertions instance for chaining.</returns>
+    /// <exception cref="DbContextAssertionException">
+    /// The DbSet contains at least one entity.
+    /// </exception>
+    public async Task<DbSetAssertions<TEntity>> BeEmpty()
+    {
+        var actual = await _query.CountAsync().ConfigureAwait(false);
+        if (actual != 0)
+        {
+            throw new DbContextAssertionException(
+                $"Expected DbSet<{typeof(TEntity).Name}> to be empty, but found {actual} entities.");
+        }
+
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Asserts that the wrapped <see cref="DbSet{TEntity}"/> contains at least one entity.
+    /// </summary>
+    /// <returns>This assertions instance for chaining.</returns>
+    /// <exception cref="DbContextAssertionException">
+    /// The DbSet is empty.
+    /// </exception>
+    public async Task<DbSetAssertions<TEntity>> NotBeEmpty()
+    {
+        var actual = await _query.AnyAsync().ConfigureAwait(false);
+        if (!actual)
+        {
+            throw new DbContextAssertionException(
+                $"Expected DbSet<{typeof(TEntity).Name}> to contain at least one entity, but it was empty.");
+        }
+
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Asserts that at least one entity in the wrapped <see cref="DbSet{TEntity}"/> satisfies
+    /// <paramref name="predicate"/>.
+    /// </summary>
+    /// <param name="predicate">Expression evaluated server-side via EF.</param>
+    /// <returns>This assertions instance for chaining.</returns>
+    /// <exception cref="DbContextAssertionException">
+    /// No entity matches <paramref name="predicate"/>.
+    /// </exception>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is null.</exception>
+    public async Task<DbSetAssertions<TEntity>> Contain(Expression<Func<TEntity, bool>> predicate)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+
+        var matched = await _query.AnyAsync(predicate).ConfigureAwait(false);
+        if (!matched)
+        {
+            var total = await _query.CountAsync().ConfigureAwait(false);
+            throw new DbContextAssertionException(
+                $"Expected DbSet<{typeof(TEntity).Name}> to contain an entity matching ({predicate}), " +
+                $"but no matching entity was found among {total} entities.");
+        }
+
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Asserts that no entity in the wrapped <see cref="DbSet{TEntity}"/> satisfies
+    /// <paramref name="predicate"/>.
+    /// </summary>
+    /// <param name="predicate">Expression evaluated server-side via EF.</param>
+    /// <returns>This assertions instance for chaining.</returns>
+    /// <exception cref="DbContextAssertionException">
+    /// At least one entity matches <paramref name="predicate"/>.
+    /// </exception>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is null.</exception>
+    public async Task<DbSetAssertions<TEntity>> NotContain(Expression<Func<TEntity, bool>> predicate)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+
+        var matched = await _query.CountAsync(predicate).ConfigureAwait(false);
+        if (matched != 0)
+        {
+            throw new DbContextAssertionException(
+                $"Expected DbSet<{typeof(TEntity).Name}> to contain NO entity matching ({predicate}), " +
+                $"but {matched} matching entities were found.");
+        }
+
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Asserts that every entity in the wrapped <see cref="DbSet{TEntity}"/> satisfies
+    /// <paramref name="predicate"/>.
+    /// </summary>
+    /// <param name="predicate">Expression evaluated server-side via EF.</param>
+    /// <returns>This assertions instance for chaining.</returns>
+    /// <exception cref="DbContextAssertionException">
+    /// At least one entity fails <paramref name="predicate"/>.
+    /// </exception>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is null.</exception>
+    public async Task<DbSetAssertions<TEntity>> AllSatisfy(Expression<Func<TEntity, bool>> predicate)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+
+        var total = await _query.CountAsync().ConfigureAwait(false);
+        if (total == 0)
+        {
+            // Vacuously true: an empty set "all satisfies" any predicate.
+            return this;
+        }
+
+        var matching = await _query.CountAsync(predicate).ConfigureAwait(false);
+        if (matching != total)
+        {
+            var failing = total - matching;
+            throw new DbContextAssertionException(
+                $"Expected all {total} entities in DbSet<{typeof(TEntity).Name}> to satisfy ({predicate}), " +
+                $"but {failing} of {total} failed.");
+        }
+
+        return this;
+    }
+}

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs
@@ -1,0 +1,256 @@
+using Microsoft.EntityFrameworkCore;
+using Wolfgang.DbContextBuilderCore.Assertions;
+using Wolfgang.DbContextBuilderCore.Tests.Unit.Models;
+
+namespace Wolfgang.DbContextBuilderCore.Tests.Unit;
+
+/// <summary>
+/// Tests for the fluent DbSet assertion extensions under
+/// <see cref="DbContextAssertionsExtensions"/> / <see cref="DbSetAssertions{TEntity}"/>.
+/// All assertions are exercised against a SQLite in-memory DbContext seeded with a few
+/// rows of TableWithDefaults to keep the test focused on the assertion logic, not on
+/// AdventureWorks seeding.
+/// </summary>
+public class DbSetAssertionsTests
+{
+
+    private static async Task<BasicContext> CreateSeededContextAsync(int rowCount)
+    {
+        using var builder = new DbContextBuilder<BasicContext>().UseInMemory();
+        var seeds = new TableWithDefaults[rowCount];
+        for (var i = 0; i < rowCount; i++)
+        {
+            seeds[i] = new TableWithDefaults { Id = i + 1 };
+        }
+        builder.SeedWith(seeds);
+        return await builder.BuildAsync();
+    }
+
+
+
+    /// <summary>
+    /// Verifies HaveCount passes when the actual row count matches.
+    /// </summary>
+    [Fact]
+    public async Task HaveCount_when_count_matches_does_not_throw()
+    {
+        await using var context = await CreateSeededContextAsync(3);
+
+        await context.Set<TableWithDefaults>().Should().HaveCount(3);
+    }
+
+
+
+    /// <summary>
+    /// Verifies HaveCount throws when the actual count differs, and the message identifies
+    /// the entity type plus both expected and actual values.
+    /// </summary>
+    [Fact]
+    public async Task HaveCount_when_count_differs_throws_with_informative_message()
+    {
+        await using var context = await CreateSeededContextAsync(3);
+
+        var ex = await Assert.ThrowsAsync<DbContextAssertionException>(
+            async () => await context.Set<TableWithDefaults>().Should().HaveCount(5));
+
+        Assert.Contains("TableWithDefaults", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("5 entities", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("found 3", ex.Message, StringComparison.Ordinal);
+    }
+
+
+
+    /// <summary>
+    /// Verifies BeEmpty passes when the DbSet has no rows.
+    /// </summary>
+    [Fact]
+    public async Task BeEmpty_when_set_is_empty_does_not_throw()
+    {
+        await using var context = await CreateSeededContextAsync(0);
+
+        await context.Set<TableWithDefaults>().Should().BeEmpty();
+    }
+
+
+
+    /// <summary>
+    /// Verifies BeEmpty throws when the DbSet has rows.
+    /// </summary>
+    [Fact]
+    public async Task BeEmpty_when_set_has_rows_throws()
+    {
+        await using var context = await CreateSeededContextAsync(2);
+
+        var ex = await Assert.ThrowsAsync<DbContextAssertionException>(
+            async () => await context.Set<TableWithDefaults>().Should().BeEmpty());
+
+        Assert.Contains("be empty", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("found 2", ex.Message, StringComparison.Ordinal);
+    }
+
+
+
+    /// <summary>
+    /// Verifies NotBeEmpty passes when the DbSet has any rows.
+    /// </summary>
+    [Fact]
+    public async Task NotBeEmpty_when_set_has_rows_does_not_throw()
+    {
+        await using var context = await CreateSeededContextAsync(1);
+
+        await context.Set<TableWithDefaults>().Should().NotBeEmpty();
+    }
+
+
+
+    /// <summary>
+    /// Verifies NotBeEmpty throws when the DbSet is empty.
+    /// </summary>
+    [Fact]
+    public async Task NotBeEmpty_when_set_is_empty_throws()
+    {
+        await using var context = await CreateSeededContextAsync(0);
+
+        var ex = await Assert.ThrowsAsync<DbContextAssertionException>(
+            async () => await context.Set<TableWithDefaults>().Should().NotBeEmpty());
+
+        Assert.Contains("at least one entity", ex.Message, StringComparison.Ordinal);
+    }
+
+
+
+    /// <summary>
+    /// Verifies Contain passes when at least one row matches the predicate.
+    /// </summary>
+    [Fact]
+    public async Task Contain_when_predicate_matches_does_not_throw()
+    {
+        await using var context = await CreateSeededContextAsync(3);
+
+        await context.Set<TableWithDefaults>().Should().Contain(t => t.Id == 2);
+    }
+
+
+
+    /// <summary>
+    /// Verifies Contain throws when no rows match the predicate, and the message includes
+    /// the total row count for context.
+    /// </summary>
+    [Fact]
+    public async Task Contain_when_no_match_throws_with_total_count_in_message()
+    {
+        await using var context = await CreateSeededContextAsync(3);
+
+        var ex = await Assert.ThrowsAsync<DbContextAssertionException>(
+            async () => await context.Set<TableWithDefaults>().Should().Contain(t => t.Id == 99));
+
+        Assert.Contains("TableWithDefaults", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("among 3 entities", ex.Message, StringComparison.Ordinal);
+    }
+
+
+
+    /// <summary>
+    /// Verifies NotContain passes when no rows match the predicate.
+    /// </summary>
+    [Fact]
+    public async Task NotContain_when_no_match_does_not_throw()
+    {
+        await using var context = await CreateSeededContextAsync(3);
+
+        await context.Set<TableWithDefaults>().Should().NotContain(t => t.Id == 999);
+    }
+
+
+
+    /// <summary>
+    /// Verifies NotContain throws when at least one row matches the predicate, and the
+    /// message reports the matching count.
+    /// </summary>
+    [Fact]
+    public async Task NotContain_when_predicate_matches_throws_with_count()
+    {
+        await using var context = await CreateSeededContextAsync(3);
+
+        var ex = await Assert.ThrowsAsync<DbContextAssertionException>(
+            async () => await context.Set<TableWithDefaults>().Should().NotContain(t => t.Id >= 1));
+
+        Assert.Contains("3 matching entities", ex.Message, StringComparison.Ordinal);
+    }
+
+
+
+    /// <summary>
+    /// Verifies AllSatisfy passes when every row satisfies the predicate.
+    /// </summary>
+    [Fact]
+    public async Task AllSatisfy_when_every_row_matches_does_not_throw()
+    {
+        await using var context = await CreateSeededContextAsync(3);
+
+        await context.Set<TableWithDefaults>().Should().AllSatisfy(t => t.Id > 0);
+    }
+
+
+
+    /// <summary>
+    /// Verifies AllSatisfy on an empty set is vacuously true (does not throw) — matches the
+    /// LINQ All semantic.
+    /// </summary>
+    [Fact]
+    public async Task AllSatisfy_when_set_is_empty_does_not_throw()
+    {
+        await using var context = await CreateSeededContextAsync(0);
+
+        await context.Set<TableWithDefaults>().Should().AllSatisfy(t => t.Id == 1234567);
+    }
+
+
+
+    /// <summary>
+    /// Verifies AllSatisfy throws when at least one row fails, and the message tells the
+    /// reader how many of how many failed.
+    /// </summary>
+    [Fact]
+    public async Task AllSatisfy_when_some_rows_fail_throws_with_failure_count()
+    {
+        await using var context = await CreateSeededContextAsync(3);
+
+        var ex = await Assert.ThrowsAsync<DbContextAssertionException>(
+            async () => await context.Set<TableWithDefaults>().Should().AllSatisfy(t => t.Id == 1));
+
+        Assert.Contains("3 entities", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("2 of 3 failed", ex.Message, StringComparison.Ordinal);
+    }
+
+
+
+    /// <summary>
+    /// Verifies the chain returns this from each assertion so multiple checks can be
+    /// composed in a single await without throwing.
+    /// </summary>
+    [Fact]
+    public async Task Chained_assertions_compose_cleanly_when_all_pass()
+    {
+        await using var context = await CreateSeededContextAsync(3);
+
+        await (await (await context.Set<TableWithDefaults>().Should()
+            .HaveCount(3))
+            .NotBeEmpty())
+            .AllSatisfy(t => t.Id > 0);
+    }
+
+
+
+    /// <summary>
+    /// Verifies the IQueryable overload of <c>.Should()</c> works against a filtered query
+    /// — letting callers assert on subsets without materializing them first.
+    /// </summary>
+    [Fact]
+    public async Task Should_on_filtered_IQueryable_asserts_against_the_filter()
+    {
+        await using var context = await CreateSeededContextAsync(5);
+
+        await context.Set<TableWithDefaults>().Where(t => t.Id <= 3).Should().HaveCount(3);
+    }
+}

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs
@@ -253,4 +253,26 @@ public class DbSetAssertionsTests
 
         await context.Set<TableWithDefaults>().Where(t => t.Id <= 3).Should().HaveCount(3);
     }
+
+
+
+    /// <summary>
+    /// Verifies all three <see cref="DbContextAssertionException"/> constructors behave as
+    /// the standard <see cref="Exception"/> pattern requires (default message, supplied
+    /// message, message + inner exception).
+    /// </summary>
+    [Fact]
+    public void DbContextAssertionException_constructors_behave_as_expected()
+    {
+        var defaultEx = new DbContextAssertionException();
+        Assert.NotNull(defaultEx.Message);
+
+        var msgEx = new DbContextAssertionException("boom");
+        Assert.Equal("boom", msgEx.Message);
+
+        var inner = new InvalidOperationException("inner");
+        var wrappedEx = new DbContextAssertionException("outer", inner);
+        Assert.Equal("outer", wrappedEx.Message);
+        Assert.Same(inner, wrappedEx.InnerException);
+    }
 }

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs
@@ -7,9 +7,9 @@ namespace Wolfgang.DbContextBuilderCore.Tests.Unit;
 /// <summary>
 /// Tests for the fluent DbSet assertion extensions under
 /// <see cref="DbContextAssertionsExtensions"/> / <see cref="DbSetAssertions{TEntity}"/>.
-/// All assertions are exercised against a SQLite in-memory DbContext seeded with a few
+/// All assertions are exercised against the EF Core InMemory provider seeded with a few
 /// rows of TableWithDefaults to keep the test focused on the assertion logic, not on
-/// AdventureWorks seeding.
+/// AdventureWorks seeding or relational SQLite quirks.
 /// </summary>
 public class DbSetAssertionsTests
 {
@@ -274,5 +274,50 @@ public class DbSetAssertionsTests
         var wrappedEx = new DbContextAssertionException("outer", inner);
         Assert.Equal("outer", wrappedEx.Message);
         Assert.Same(inner, wrappedEx.InnerException);
+    }
+
+
+
+    /// <summary>
+    /// The DbSet variant of <c>Should()</c> must reject a null set argument.
+    /// </summary>
+    [Fact]
+    public void Should_on_DbSet_when_set_is_null_throws_ArgumentNullException()
+    {
+        DbSet<TableWithDefaults>? set = null;
+
+        var ex = Assert.Throws<ArgumentNullException>(() => set!.Should());
+        Assert.Equal("set", ex.ParamName);
+    }
+
+
+
+    /// <summary>
+    /// The IQueryable variant of <c>Should()</c> must reject a null query argument.
+    /// </summary>
+    [Fact]
+    public void Should_on_IQueryable_when_query_is_null_throws_ArgumentNullException()
+    {
+        IQueryable<TableWithDefaults>? query = null;
+
+        var ex = Assert.Throws<ArgumentNullException>(() => query!.Should());
+        Assert.Equal("query", ex.ParamName);
+    }
+
+
+
+    /// <summary>
+    /// Contain/NotContain/AllSatisfy must reject a null predicate via
+    /// <see cref="ArgumentNullException.ThrowIfNull(object?, string?)"/>.
+    /// </summary>
+    [Fact]
+    public async Task Predicate_assertions_when_predicate_is_null_throw_ArgumentNullException()
+    {
+        await using var context = await CreateSeededContextAsync(1);
+        var assertions = context.Set<TableWithDefaults>().Should();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => assertions.Contain(null!));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => assertions.NotContain(null!));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => assertions.AllSatisfy(null!));
     }
 }


### PR DESCRIPTION
## Summary

Introduces a small fluent assertion surface for testing DbContextBuilder-built contexts under the new `Wolfgang.DbContextBuilderCore.Assertions` namespace:

- `DbSetAssertions<TEntity>` — async chainable: `HaveCount`, `BeEmpty`, `NotBeEmpty`, `Contain`, `NotContain`, `AllSatisfy`. Each runs the query via EF and returns `this` for chaining.
- `DbContextAssertionsExtensions.Should()` — entry-point on `DbSet<TEntity>` and `IQueryable<TEntity>`.
- `DbContextAssertionException` — typed failure with EF-aware message including the entity type and the specific check that failed.

Linked into all five EF Core shims (EF6-EF10) via the existing `<Compile Include>` + `Link` pattern. 15 new unit tests in `DbSetAssertionsTests` cover pass / fail / chaining / IQueryable paths against an `InMemory`-backed `BasicContext`.

This is the minimum viable assertion surface from #106's proposal — the additional methods listed there (HaveCountGreaterThan/LessThan, Contain(entity), HaveSeededData, etc.) are explicitly deferred as roadmap for follow-up PRs.

Closes #106

## Test plan

- [x] `dotnet build -c Release` — clean across all 6 src projects + all test projects
- [x] 15 new tests in `DbSetAssertionsTests` pass on net10.0
- [ ] CI: Stage 1 Linux + Stage 2 Windows + Stage 3 macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)