### PR TITLE
chore: repo hygiene sweep (review items 3, 22, 32)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -431,3 +431,4 @@ nuget-packages/
 docfx_project/_site/
 docfx_project/obj/
 
+coverage-tmp/

--- a/src/Wolfgang.DbContextBuilder-Core/AutoFixtureRandomEntityCreator.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/AutoFixtureRandomEntityCreator.cs
@@ -13,16 +13,13 @@ internal class AutoFixtureRandomEntityCreator : ICreateRandomEntities
 {
     public AutoFixtureRandomEntityCreator()
     {
-        // AutoFixture 4.x does not have built in support for DateOnly and TimeOnly. Version is supposed to 
+        // AutoFixture 4.x does not have built-in support for DateOnly and TimeOnly. Add factories
+        // that convert from a generated DateTime so AutoFixture can produce these types.
         Fixture.Customize<DateOnly>(o => o.FromFactory((DateTime dt) => DateOnly.FromDateTime(dt)));
         Fixture.Customize<TimeOnly>(o => o.FromFactory((DateTime dt) => TimeOnly.FromDateTime(dt)));
 
-        // Prevents issues with circular references
-        Fixture.Behaviors
-            .OfType<ThrowingRecursionBehavior>()
-            .ToList()
-            .ForEach(b => Fixture.Behaviors.Remove(b));
-        Fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+        // Prevents issues with circular references — the customization itself handles
+        // swapping ThrowingRecursionBehavior for OmitOnRecursionBehavior idempotently.
         Fixture.Customize(new NoCircularReferencesCustomization());
         Fixture.Customize(new IgnoreVirtualMembersCustomization());
     }

--- a/tests/Wolfgang.DbContextBuilder-Core-EF10.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF10.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF10.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF10.csproj
@@ -164,7 +164,7 @@
 
 
 	<PropertyGroup>
-		<!-- CA1707 (underscores) is intentional: test naming uses MethodUnderTest_when_condition_expected_result per CLAUDE.md. -->
+		<!-- CA1707 (underscores) is intentional: test method names follow the MethodUnderTest_when_condition_expected_result convention. -->
 		<NoWarn>$(NoWarn);CA1707</NoWarn>
 	</PropertyGroup>
 

--- a/tests/Wolfgang.DbContextBuilder-Core-EF10.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF10.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF10.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF10.csproj
@@ -13,7 +13,6 @@
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/DbContextBuilder</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<RepositoryUrl>https://github.com/Chris-Wolfgang/DbContextBuilder</RepositoryUrl>
-		<AssemblyVersion>1.0.0</AssemblyVersion>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<PackageIcon></PackageIcon>
@@ -165,6 +164,7 @@
 
 
 	<PropertyGroup>
+		<!-- CA1707 (underscores) is intentional: test naming uses MethodUnderTest_when_condition_expected_result per CLAUDE.md. -->
 		<NoWarn>$(NoWarn);CA1707</NoWarn>
 	</PropertyGroup>
 

--- a/tests/Wolfgang.DbContextBuilder-Core-EF6.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF6.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF6.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF6.csproj
@@ -13,7 +13,6 @@
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/DbContextBuilder</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<RepositoryUrl>https://github.com/Chris-Wolfgang/DbContextBuilder</RepositoryUrl>
-		<AssemblyVersion>1.0.0</AssemblyVersion>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<PackageIcon></PackageIcon>
@@ -182,6 +181,7 @@
 
 
 	<PropertyGroup>
+		<!-- CA1707 (underscores) is intentional: test naming uses MethodUnderTest_when_condition_expected_result per CLAUDE.md. -->
 		<NoWarn>$(NoWarn);CA1707</NoWarn>
 	</PropertyGroup>
 

--- a/tests/Wolfgang.DbContextBuilder-Core-EF6.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF6.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF6.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF6.csproj
@@ -181,7 +181,7 @@
 
 
 	<PropertyGroup>
-		<!-- CA1707 (underscores) is intentional: test naming uses MethodUnderTest_when_condition_expected_result per CLAUDE.md. -->
+		<!-- CA1707 (underscores) is intentional: test method names follow the MethodUnderTest_when_condition_expected_result convention. -->
 		<NoWarn>$(NoWarn);CA1707</NoWarn>
 	</PropertyGroup>
 

--- a/tests/Wolfgang.DbContextBuilder-Core-EF7.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF7.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF7.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF7.csproj
@@ -13,7 +13,6 @@
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/DbContextBuilder</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<RepositoryUrl>https://github.com/Chris-Wolfgang/DbContextBuilder</RepositoryUrl>
-		<AssemblyVersion>1.0.0</AssemblyVersion>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<PackageIcon></PackageIcon>
@@ -180,6 +179,7 @@
 
 
 	<PropertyGroup>
+		<!-- CA1707 (underscores) is intentional: test naming uses MethodUnderTest_when_condition_expected_result per CLAUDE.md. -->
 		<NoWarn>$(NoWarn);CA1707</NoWarn>
 	</PropertyGroup>
 

--- a/tests/Wolfgang.DbContextBuilder-Core-EF7.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF7.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF7.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF7.csproj
@@ -179,7 +179,7 @@
 
 
 	<PropertyGroup>
-		<!-- CA1707 (underscores) is intentional: test naming uses MethodUnderTest_when_condition_expected_result per CLAUDE.md. -->
+		<!-- CA1707 (underscores) is intentional: test method names follow the MethodUnderTest_when_condition_expected_result convention. -->
 		<NoWarn>$(NoWarn);CA1707</NoWarn>
 	</PropertyGroup>
 

--- a/tests/Wolfgang.DbContextBuilder-Core-EF8.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF8.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF8.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF8.csproj
@@ -164,7 +164,7 @@
 
 
 	<PropertyGroup>
-		<!-- CA1707 (underscores) is intentional: test naming uses MethodUnderTest_when_condition_expected_result per CLAUDE.md. -->
+		<!-- CA1707 (underscores) is intentional: test method names follow the MethodUnderTest_when_condition_expected_result convention. -->
 		<NoWarn>$(NoWarn);CA1707</NoWarn>
 	</PropertyGroup>
 

--- a/tests/Wolfgang.DbContextBuilder-Core-EF8.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF8.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF8.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF8.csproj
@@ -13,7 +13,6 @@
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/DbContextBuilder</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<RepositoryUrl>https://github.com/Chris-Wolfgang/DbContextBuilder</RepositoryUrl>
-		<AssemblyVersion>1.0.0</AssemblyVersion>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<PackageIcon></PackageIcon>
@@ -165,6 +164,7 @@
 
 
 	<PropertyGroup>
+		<!-- CA1707 (underscores) is intentional: test naming uses MethodUnderTest_when_condition_expected_result per CLAUDE.md. -->
 		<NoWarn>$(NoWarn);CA1707</NoWarn>
 	</PropertyGroup>
 

--- a/tests/Wolfgang.DbContextBuilder-Core-EF9.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF9.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF9.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF9.csproj
@@ -164,7 +164,7 @@
 
 
 	<PropertyGroup>
-		<!-- CA1707 (underscores) is intentional: test naming uses MethodUnderTest_when_condition_expected_result per CLAUDE.md. -->
+		<!-- CA1707 (underscores) is intentional: test method names follow the MethodUnderTest_when_condition_expected_result convention. -->
 		<NoWarn>$(NoWarn);CA1707</NoWarn>
 	</PropertyGroup>
 

--- a/tests/Wolfgang.DbContextBuilder-Core-EF9.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF9.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF9.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF9.csproj
@@ -13,7 +13,6 @@
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/DbContextBuilder</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<RepositoryUrl>https://github.com/Chris-Wolfgang/DbContextBuilder</RepositoryUrl>
-		<AssemblyVersion>1.0.0</AssemblyVersion>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<PackageIcon></PackageIcon>
@@ -165,6 +164,7 @@
 
 
 	<PropertyGroup>
+		<!-- CA1707 (underscores) is intentional: test naming uses MethodUnderTest_when_condition_expected_result per CLAUDE.md. -->
 		<NoWarn>$(NoWarn);CA1707</NoWarn>
 	</PropertyGroup>
 

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit.csproj
@@ -182,7 +182,7 @@
 
 
 	<PropertyGroup>
-		<!-- CA1707 (underscores) is intentional: test naming uses MethodUnderTest_when_condition_expected_result per CLAUDE.md. -->
+		<!-- CA1707 (underscores) is intentional: test method names follow the MethodUnderTest_when_condition_expected_result convention. -->
 		<NoWarn>$(NoWarn);CA1707</NoWarn>
 	</PropertyGroup>
 

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit.csproj
@@ -13,7 +13,6 @@
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/DbContextBuilder</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<RepositoryUrl>https://github.com/Chris-Wolfgang/DbContextBuilder</RepositoryUrl>
-		<AssemblyVersion>1.0.0</AssemblyVersion>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<PackageIcon></PackageIcon>
@@ -183,6 +182,7 @@
 
 
 	<PropertyGroup>
+		<!-- CA1707 (underscores) is intentional: test naming uses MethodUnderTest_when_condition_expected_result per CLAUDE.md. -->
 		<NoWarn>$(NoWarn);CA1707</NoWarn>
 	</PropertyGroup>
 

--- a/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/Wolfgang.DbContextBuilder-EF6.Tests.Unit.csproj
+++ b/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/Wolfgang.DbContextBuilder-EF6.Tests.Unit.csproj
@@ -11,7 +11,6 @@
 		<Copyright>Copyright 2025 Chris Wolfgang</Copyright>
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/DbContextBuilder</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/Chris-Wolfgang/DbContextBuilder</RepositoryUrl>
-		<AssemblyVersion>1.0.0</AssemblyVersion>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<SignAssembly>False</SignAssembly>
 		<IsTestProject>true</IsTestProject>
@@ -37,6 +36,7 @@
 	</ItemGroup>
 
 	<PropertyGroup>
+		<!-- CA1707 (underscores) is intentional: test naming uses MethodUnderTest_when_condition_expected_result per CLAUDE.md. -->
 		<NoWarn>$(NoWarn);CA1707</NoWarn>
 	</PropertyGroup>
 

--- a/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/Wolfgang.DbContextBuilder-EF6.Tests.Unit.csproj
+++ b/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/Wolfgang.DbContextBuilder-EF6.Tests.Unit.csproj
@@ -36,7 +36,7 @@
 	</ItemGroup>
 
 	<PropertyGroup>
-		<!-- CA1707 (underscores) is intentional: test naming uses MethodUnderTest_when_condition_expected_result per CLAUDE.md. -->
+		<!-- CA1707 (underscores) is intentional: test method names follow the MethodUnderTest_when_condition_expected_result convention. -->
 		<NoWarn>$(NoWarn);CA1707</NoWarn>
 	</PropertyGroup>
 


### PR DESCRIPTION
## Summary

Three small hygiene fixes surfaced by the full code review:

- Drop stale `<AssemblyVersion>1.0.0</AssemblyVersion>` from all 7 test csprojs (tests are not shipped — let the SDK derive it).
- Document the `<NoWarn>$(NoWarn);CA1707</NoWarn>` suppression in every test csproj with a one-liner explaining the test-naming convention from CLAUDE.md.
- Collapse the manual recursion-behavior swap in `AutoFixtureRandomEntityCreator` — `NoCircularReferencesCustomization` already does the same swap idempotently. Also repair the truncated DateOnly/TimeOnly comment.

Plus: add `coverage-tmp/` to `.gitignore`.

Finding #2 (committed `.user` files) was a false positive — `.gitignore` already covers `*.user` and `*.DotSettings.user`; neither file is tracked.

## Test plan

- [x] `dotnet build -c Release` — clean
- [ ] CI passes