### PR TITLE
docs: fill docfx stubs + add README TFM + API tables (review items 23-26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Each package targets the .NET runtimes its EF version requires:
 
 | Package | Target Frameworks |
 |---|---|
-| `Wolfgang.DbContextBuilder-Core` / `-Core-EF6` | `net6.0` |
+| `Wolfgang.DbContextBuilder-Core` | `net10.0` |
+| `Wolfgang.DbContextBuilder-Core-EF6` | `net6.0` |
 | `Wolfgang.DbContextBuilder-Core-EF7` | `net7.0` |
 | `Wolfgang.DbContextBuilder-Core-EF8` | `net8.0` |
 | `Wolfgang.DbContextBuilder-Core-EF9` | `net9.0` |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ DbContextBuilder ships as a family of packages — install the one that matches 
 dotnet add package Wolfgang.DbContextBuilder-Core-EF8
 ```
 
+### Target frameworks
+
+Each package targets the .NET runtimes its EF version requires:
+
+| Package | Target Frameworks |
+|---|---|
+| `Wolfgang.DbContextBuilder-Core` / `-Core-EF6` | `net6.0` |
+| `Wolfgang.DbContextBuilder-Core-EF7` | `net7.0` |
+| `Wolfgang.DbContextBuilder-Core-EF8` | `net8.0` |
+| `Wolfgang.DbContextBuilder-Core-EF9` | `net9.0` |
+| `Wolfgang.DbContextBuilder-Core-EF10` | `net10.0` |
+| `Wolfgang.DbContextBuilder-EF6` (classic) | `net462; net47; net471; net472; net48; net481` |
+
 ---
 
 ## 📄 License
@@ -88,3 +101,24 @@ var context = await new DbContextBuilder<YourDbContext>()
 // Use the context in your tests
 var sut = new YourService(context);
 ```
+
+---
+
+## 📖 API surface
+
+The Core package exposes a small, focused surface. The full reference is on the [docs site](https://Chris-Wolfgang.github.io/DbContextBuilder/api/Wolfgang.DbContextBuilderCore.html); the most-used entry points are:
+
+| Type / Method | What it does |
+|---|---|
+| `DbContextBuilder<T>` | The builder itself. Construct one per test, chain configuration, then call `BuildAsync()`. |
+| `.UseInMemory()` | EF Core InMemory provider. Fastest, ignores relational constraints. |
+| `.UseSqlite()` | SQLite in-memory provider. Enforces relational constraints. |
+| `.UseSqliteForMsSqlServer()` | SQLite in-memory with a SQL-Server compatibility layer that flattens schema-qualified table names and rewrites SQL-Server-specific default-value SQL. |
+| `.UseAutoFixture()` | Plug AutoFixture in as the random-entity generator (used by `SeedWithRandom`). |
+| `.UseDbContextOptionsBuilder(opts)` | Bring your own `DbContextOptionsBuilder<T>` to override the provider entirely. |
+| `.UseCustomRandomEntityCreator(creator)` | Plug in any `ICreateRandomEntities` implementation. |
+| `.SeedWith<TEntity>(...)` | Seed specific rows. Accepts `IEnumerable<T>` or `params T[]`. |
+| `.SeedWithRandom<TEntity>(count, [func])` | Seed N random rows. Optional `func` mutates each generated entity. |
+| `.BuildAsync()` | Materialize the `DbContext`. The builder owns the underlying connection; dispose the context with `await using`. |
+| `SqliteModelCustomizer` | Customization hooks for the SQLite-for-SQL-Server mode: `OverrideTableRenaming`, `OverrideDefaultValueHandling`, `OverrideComputedValueHandling`, `OverrideManyToManyTableHandling`, `DefaultValueMap`. |
+| `ICreateDbContext` / `ICreateRandomEntities` | Extension points for plugging in your own provider or random-entity generator. |

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -1,1 +1,61 @@
 # Getting Started
+
+## 1. Install the package that matches your EF version
+
+```bash
+# Pick whichever matches your project's EF version
+dotnet add package Wolfgang.DbContextBuilder-Core-EF8
+```
+
+For the full version-to-package mapping, see the [Installation table in the README](https://github.com/Chris-Wolfgang/DbContextBuilder#-installation).
+
+## 2. Build your first DbContext
+
+```csharp
+using Wolfgang.DbContextBuilderCore;
+
+await using var context = await new DbContextBuilder<MyDbContext>()
+    .UseInMemory()
+    .SeedWith(new User { Id = 1, Name = "Alice" })
+    .BuildAsync();
+
+var sut = new UserService(context);
+var user = await sut.GetByIdAsync(1);
+
+Assert.Equal("Alice", user.Name);
+```
+
+`BuildAsync()` returns a real `MyDbContext` instance whose state matches the seeds you provided. The builder owns the underlying connection; `await using` disposes both.
+
+## 3. Pick a provider
+
+The builder ships three providers out of the box:
+
+- `.UseInMemory()` — EF Core's InMemory provider. Fastest, but ignores relational constraints (foreign keys, indexes, default values). Good for unit tests of code that doesn't depend on SQL semantics.
+- `.UseSqlite()` — SQLite in-memory. Enforces relational constraints. Each builder uses a unique in-memory database; contexts built from the same builder share state.
+- `.UseSqliteForMsSqlServer()` — SQLite in-memory with a compatibility layer that flattens `[Schema].[Table]` to `Schema_Table` and rewrites SQL-Server-specific default-value SQL (`getdate()`, `newid()`, etc.) into SQLite equivalents. Lets you exercise a production SQL-Server `DbContext` without modification.
+
+## 4. Seed with data
+
+Two ways to seed:
+
+```csharp
+// Specific data — for predictable assertions
+.SeedWith(new User { Id = 1, Name = "Alice" })
+.SeedWith(new[] { user1, user2, user3 })
+
+// Random data — for realistic row counts. Uses AutoFixture under the hood;
+// plug in a custom ICreateRandomEntities to control generation.
+.SeedWithRandom<Order>(count: 20)
+```
+
+`SeedWith` and `SeedWithRandom` are chainable in any order. The builder accumulates all seeds and inserts them when `BuildAsync()` runs.
+
+## 5. Customize the model (SQLite for SQL Server only)
+
+`SqliteModelCustomizer` exposes hooks to override the schema-renaming heuristic, the default-value SQL translation, the computed-column handling, and the many-to-many join-table renaming. See the [API reference](../api/Wolfgang.DbContextBuilderCore.SqliteModelCustomizer.html) for the exact signatures.
+
+## Where to go next
+
+- [API reference](../api/Wolfgang.DbContextBuilderCore.html) — every public type and method
+- [GitHub repository](https://github.com/Chris-Wolfgang/DbContextBuilder) — source, issues, releases

--- a/docfx_project/docs/introduction.md
+++ b/docfx_project/docs/introduction.md
@@ -1,1 +1,38 @@
 # Introduction
+
+DbContextBuilder is a fluent builder for Entity Framework `DbContext` instances intended for use in tests. It wraps the boilerplate of configuring an in-memory provider, seeding data, and building a context into a single chainable API so test setup looks like the data the test cares about — not the plumbing.
+
+## Why a builder?
+
+Tests that need a `DbContext` usually need one with:
+
+- A specific provider (InMemory, SQLite in-memory, etc.) so the test does not touch a real database
+- Specific rows of specific entities so the assertions are predictable
+- Sometimes additional random rows so the SUT sees realistic data volumes
+- An options builder configured exactly the way the test scenario expects
+
+Wiring those up manually for every test costs a lot of repeated lines. `DbContextBuilder<T>` collapses them into:
+
+```csharp
+var context = await new DbContextBuilder<MyDbContext>()
+    .UseInMemory()
+    .SeedWith(new User { Id = 1, Name = "Alice" })
+    .SeedWithRandom<Order>(20)
+    .BuildAsync();
+```
+
+The same builder works against the InMemory provider, SQLite in-memory, and a SQL-Server-compatibility SQLite mode that flattens schema-qualified table names so a typical production `DbContext` can be exercised without code changes.
+
+## Package family
+
+DbContextBuilder ships one package per supported EF version so you can install only what you need:
+
+- `Wolfgang.DbContextBuilder-Core-EF6` through `-Core-EF10` — pinned to a single EF Core major
+- `Wolfgang.DbContextBuilder-EF6` — for projects still on classic Entity Framework 6 (`System.Data.Entity`)
+
+Pick the one that matches your project's EF flavor. See the [README](https://github.com/Chris-Wolfgang/DbContextBuilder) for the full installation matrix.
+
+## Where to go next
+
+- [Getting started](getting-started.html) — install, build a first `DbContext`, run a first test
+- [API](../api/Wolfgang.DbContextBuilderCore.html) — generated reference for every public type


### PR DESCRIPTION
## Summary

- **docfx stubs filled**: `docfx_project/docs/introduction.md` and `getting-started.md` were empty header-only files linked from the landing page and publishing as blank pages. Replaced with real content (what DbContextBuilder is, install + first context, provider trade-offs, seed patterns).
- **README Target Frameworks table**: maps each package to its runtime (`net6.0`-`net10.0` for the EF Core variants; `net462`-`net481` for classic EF6).
- **README API surface section**: enumerates the main public entry points with a one-line description and a link to the generated docs.

The Assertions API (review item #8) is intentionally deferred to a follow-up that lands together with #265 — that work isn't on vNext yet.

Finding #28 (badge using `event=pull_request_target`) was a false positive: pr.yaml actually triggers on `pull_request_target`, so the badge is correct.

## Test plan

- [ ] CI passes
- [ ] Docs site renders the two filled pages