### PR TITLE
docs: XML doc accuracy sweep across Core + EF6 (review items 4-7, 13-15, 17-19, 30)

### DIFF
--- a/src/Wolfgang.DbContextBuilder-Core/AutoFixtureRandomEntityCreator.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/AutoFixtureRandomEntityCreator.cs
@@ -13,7 +13,8 @@ internal class AutoFixtureRandomEntityCreator : ICreateRandomEntities
 {
     public AutoFixtureRandomEntityCreator()
     {
-        // AutoFixture 4.x does not have built in support for DateOnly and TimeOnly. Version is supposed to 
+        // AutoFixture 4.x does not have built-in support for DateOnly and TimeOnly. Add factories
+        // that convert from a generated DateTime so AutoFixture can produce these types.
         Fixture.Customize<DateOnly>(o => o.FromFactory((DateTime dt) => DateOnly.FromDateTime(dt)));
         Fixture.Customize<TimeOnly>(o => o.FromFactory((DateTime dt) => TimeOnly.FromDateTime(dt)));
 
@@ -50,7 +51,7 @@ internal class AutoFixtureRandomEntityCreator : ICreateRandomEntities
     /// </summary>
     /// <param name="count">The number of entities to create</param>
     /// <typeparam name="TEntity">The type of entity to create</typeparam>
-    /// <returns>An IEnumerable{TEntity}</returns>
+    /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TEntity"/>.</returns>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is less than 1.</exception>
     public IEnumerable<TEntity> CreateRandomEntities<TEntity>(int count)
         where TEntity : class

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
@@ -31,7 +31,7 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// <summary>
     /// Instructs the builder to use InMemory as the database provider.
     /// </summary>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     public DbContextBuilder<T> UseInMemory()
     {
         CreateDbContext = new InMemoryDbContextCreator();
@@ -45,7 +45,7 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// for creating random entities.
     /// </summary>
     /// <param name="creator">The creator to use</param>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     public DbContextBuilder<T> UseCustomRandomEntityCreator(ICreateRandomEntities creator)
     {
         ArgumentNullException.ThrowIfNull(creator);
@@ -59,7 +59,7 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// Specifies a specific <see cref="DbContextOptionsBuilder{TContext}"/> instance to use when creating the DbContext.
     /// </summary>
     /// <param name="dbContextOptionsBuilder">The options builder to use when creating the DbContext.</param>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     /// <exception cref="ArgumentNullException"><paramref name="dbContextOptionsBuilder"/> is null.</exception>
     public DbContextBuilder<T> UseDbContextOptionsBuilder(DbContextOptionsBuilder<T> dbContextOptionsBuilder)
     {
@@ -76,7 +76,7 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// Populates the specified DbSet with the provided entities.
     /// </summary>
     /// <param name="entities">The entities to populate the database with</param>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     /// <exception cref="ArgumentNullException">entities is null</exception>
     /// <exception cref="ArgumentException">entities contains a null item</exception>
     /// <exception cref="ArgumentException">entities contains a string</exception>
@@ -100,7 +100,7 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// Populates the specified DbSet with the provided entities.
     /// </summary>
     /// <param name="entities">The entities to populate the database with</param>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     /// <exception cref="ArgumentNullException">entities is null</exception>
     /// <exception cref="ArgumentException">entities contains a null item</exception>
     /// <exception cref="ArgumentException">entities contains a string</exception>
@@ -135,7 +135,7 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// </summary>
     /// <param name="count">The number of items to create</param>
     /// <typeparam name="TEntity">The type of entity to create</typeparam>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     /// <exception cref="ArgumentOutOfRangeException">count is less than 1</exception>
     public DbContextBuilder<T> SeedWithRandom<TEntity>(int count) where TEntity : class
     {
@@ -160,7 +160,7 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// <param name="count">The number of items to create</param>
     /// <param name="func">A function that takes a TEntity and returns an updated TEntity</param>
     /// <typeparam name="TEntity">The type of entity to create</typeparam>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     /// <exception cref="ArgumentOutOfRangeException">count is less than 1</exception>
     public DbContextBuilder<T> SeedWithRandom<TEntity>(int count, Func<TEntity, TEntity> func) where TEntity : class
     {
@@ -188,7 +188,7 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// <param name="count">The number of items to create</param>
     /// <param name="func">A function that takes a TEntity and the index number of the entity and returns an updated TEntity</param>
     /// <typeparam name="TEntity">The type of entity to create</typeparam>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     /// <exception cref="ArgumentOutOfRangeException">count is less than 1</exception>
     public DbContextBuilder<T> SeedWithRandom<TEntity>(int count, Func<TEntity, int, TEntity> func) where TEntity : class
     {
@@ -214,7 +214,6 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// Creates a new instance of <typeparamref name="T"/> seeded with the specified data.
     /// </summary>
     /// <returns>A new instance of <typeparamref name="T"/>.</returns>
-    /// <exception cref="NotSupportedException">The specified database provider is not supported</exception>
     /// <exception cref="ObjectDisposedException">The builder has been disposed.</exception>
     public async Task<T> BuildAsync()
     {

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderAutoFixtureExtensions.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderAutoFixtureExtensions.cs
@@ -11,7 +11,7 @@ public static class DbContextBuilderAutoFixtureExtensions
     /// <summary>
     /// Tell DbContextBuilder to use AutoFixture to create random entities.
     /// </summary>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     public static DbContextBuilder<T> UseAutoFixture<T>(this DbContextBuilder<T> builder) where T : DbContext
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderSqliteExtensions.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderSqliteExtensions.cs
@@ -15,7 +15,7 @@ public static class DbContextBuilderSqliteExtensions
     /// <summary>
     /// Instructs the builder to use SQLite as the database provider.
     /// </summary>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     public static DbContextBuilder<TDbContext> UseSqlite<TDbContext>
     (
         this DbContextBuilder<TDbContext> builder
@@ -48,7 +48,7 @@ public static class DbContextBuilderSqliteExtensions
     /// <summary>
     /// Instructs the builder to use SQLite as the database provider.
     /// </summary>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     private static DbContextBuilder<TDbContext> UseSqlite<TDbContext>
     (
         this DbContextBuilder<TDbContext> builder,

--- a/src/Wolfgang.DbContextBuilder-Core/ICreateRandomEntities.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/ICreateRandomEntities.cs
@@ -11,7 +11,8 @@ public interface ICreateRandomEntities
     /// </summary>
     /// <param name="count">The number of entities to create</param>
     /// <typeparam name="TEntity">The type of entity to create</typeparam>
-    /// <returns>An IEnumerable{TEntity}</returns>
+    /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TEntity"/>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is less than 1.</exception>
     IEnumerable<TEntity> CreateRandomEntities<TEntity>(int count) where TEntity : class;
 
 }

--- a/src/Wolfgang.DbContextBuilder-Core/SqliteForMsSqlServerModelCustomizer.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/SqliteForMsSqlServerModelCustomizer.cs
@@ -18,7 +18,8 @@ public class SqliteForMsSqlServerModelCustomizer : SqliteModelCustomizer
     /// <param name="dependencies">The dependencies for the model customizer.</param>
     /// <remarks>
     /// This class should not be created directly but rather added to the service collection by
-    /// calling the UseSqliteForMsSqlServerModelCustomizer method on the DbContextBuilder class
+    /// calling <see cref="DbContextBuilderSqliteExtensions.UseSqliteForMsSqlServer{TDbContext}"/>
+    /// on a <see cref="DbContextBuilder{T}"/>.
     /// </remarks>
     public SqliteForMsSqlServerModelCustomizer(ModelCustomizerDependencies dependencies) : base(dependencies)
     {

--- a/src/Wolfgang.DbContextBuilder-Core/SqliteModelCustomizer.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/SqliteModelCustomizer.cs
@@ -15,11 +15,11 @@ namespace Wolfgang.DbContextBuilderCore;
 ///   1. Renaming tables to avoid schema issues since SQLite does not support schemas.
 ///   2. Removing computed values for columns since SQLite may not support the same functions.
 /// 
-/// You can override the functionality provided in this class or if you will be frequently working
-/// in the same database engine, you can create your own ModelCustomizer, either from scratch or
-/// derived from this one, and override the desired functionality. Once you created you can reuse
-/// it over and over again. For example, you want to create a SqliteForOracleModelCustomizer that
-/// has overrides to make an DbContext created for Oracle work in SQLite.
+/// You can override the functionality provided in this class or, if you will frequently work
+/// against the same database engine, derive your own <see cref="ModelCustomizer"/> (from
+/// scratch or from this one) and override the desired functionality. Once created it can be
+/// reused across builds. For example, you could create a <c>SqliteForOracleModelCustomizer</c>
+/// with the overrides needed to make an Oracle <see cref="DbContext"/> work against SQLite.
 /// </remarks>
 public class SqliteModelCustomizer : ModelCustomizer
 {
@@ -31,7 +31,7 @@ public class SqliteModelCustomizer : ModelCustomizer
     /// This method is called for each table in the database to rename the table since SQLite
     /// does not support schemas.  
     /// </summary>
-    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentNullException">The setter received a <c>null</c> <c>value</c>.</exception>
     /// <remarks>
     ///The default implementation renames the table by prefixing
     /// the schema name to the table name. For example, a table named "Person" in schema
@@ -59,7 +59,7 @@ public class SqliteModelCustomizer : ModelCustomizer
     /// <summary>
     /// This method is called for each column that has a computed value defined in the model.
     /// </summary>
-    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentNullException">The setter received a <c>null</c> <c>value</c>.</exception>
     /// <remarks>
     /// The default handling for this is to leave the computed value as is. However,
     /// Sqlite has limited support for computed values and the functions used in the model may
@@ -99,7 +99,7 @@ public class SqliteModelCustomizer : ModelCustomizer
     /// <summary>
     /// This method is called for each column that has a default value defined in the model.
     /// </summary>
-    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentNullException">The setter received a <c>null</c> <c>value</c>.</exception>
     /// <remarks>
     /// The default implementation checks the DefaultValueMap dictionary to see if the existing default value
     /// is contained in the dictionary and if so, replaces it with the value in the dictionary. If the
@@ -224,7 +224,7 @@ public class SqliteModelCustomizer : ModelCustomizer
     /// <summary>
     /// This action is called for each entity type to handle many-to-many join table renaming.
     /// </summary>
-    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentNullException">The setter received a <c>null</c> <c>value</c>.</exception>
     /// <remarks>
     /// The default implementation uses a heuristic to detect many-to-many join tables:
     /// an entity type with exactly two foreign keys and no navigations is assumed to be a join table.

--- a/src/Wolfgang.DbContextBuilder-EF6/AutoFixtureRandomEntityCreator.cs
+++ b/src/Wolfgang.DbContextBuilder-EF6/AutoFixtureRandomEntityCreator.cs
@@ -51,7 +51,7 @@ internal class AutoFixtureRandomEntityCreator : ICreateRandomEntities
     /// </summary>
     /// <param name="count">The number of entities to create</param>
     /// <typeparam name="TEntity">The type of entity to create</typeparam>
-    /// <returns>An IEnumerable{TEntity}</returns>
+    /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TEntity"/>.</returns>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is less than 1.</exception>
     public IEnumerable<TEntity> CreateRandomEntities<TEntity>(int count)
         where TEntity : class

--- a/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilder.cs
@@ -206,11 +206,18 @@ public class DbContextBuilder<T> where T : DbContext
     /// Creates a new instance of <typeparamref name="T"/> seeded with the configured data.
     /// </summary>
     /// <returns>A new instance of <typeparamref name="T"/>.</returns>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="MissingMethodException">
     /// <typeparamref name="T"/> does not have a constructor that accepts
-    /// (<see cref="System.Data.Common.DbConnection"/>, <see cref="bool"/>), so the in-memory backing database
-    /// could not be initialized. See the wrapped <see cref="Exception.InnerException"/> for
-    /// the underlying <see cref="MissingMethodException"/>.
+    /// (<see cref="System.Data.Common.DbConnection"/>, <see cref="bool"/>) — propagated from
+    /// <see cref="Activator.CreateInstance(Type, object[])"/> inside
+    /// <see cref="EffortDbContextCreator.CreateDbContext{TDbContext}"/>, which the builder
+    /// calls before <c>InitializeDatabase</c> can wrap it.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// The underlying <see cref="System.Data.Entity.Database"/> could not create itself
+    /// (a different failure mode than the missing-ctor case above). Wrapped by
+    /// <c>InitializeDatabase</c> with a more actionable message; the original exception is
+    /// in <see cref="Exception.InnerException"/>.
     /// </exception>
     public T Build()
     {
@@ -239,11 +246,18 @@ public class DbContextBuilder<T> where T : DbContext
     /// asynchronously.
     /// </summary>
     /// <returns>A new instance of <typeparamref name="T"/>.</returns>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="MissingMethodException">
     /// <typeparamref name="T"/> does not have a constructor that accepts
-    /// (<see cref="System.Data.Common.DbConnection"/>, <see cref="bool"/>), so the in-memory backing database
-    /// could not be initialized. See the wrapped <see cref="Exception.InnerException"/> for
-    /// the underlying <see cref="MissingMethodException"/>.
+    /// (<see cref="System.Data.Common.DbConnection"/>, <see cref="bool"/>) — propagated from
+    /// <see cref="Activator.CreateInstance(Type, object[])"/> inside
+    /// <see cref="EffortDbContextCreator.CreateDbContext{TDbContext}"/>, which the builder
+    /// calls before <c>InitializeDatabase</c> can wrap it.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// The underlying <see cref="System.Data.Entity.Database"/> could not create itself
+    /// (a different failure mode than the missing-ctor case above). Wrapped by
+    /// <c>InitializeDatabase</c> with a more actionable message; the original exception is
+    /// in <see cref="Exception.InnerException"/>.
     /// </exception>
     public async Task<T> BuildAsync()
     {

--- a/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilder.cs
@@ -35,7 +35,7 @@ public class DbContextBuilder<T> where T : DbContext
     /// for creating random entities.
     /// </summary>
     /// <param name="creator">The creator to use</param>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     /// <exception cref="ArgumentNullException"><paramref name="creator"/> is <c>null</c>.</exception>
     public DbContextBuilder<T> UseCustomRandomEntityCreator(ICreateRandomEntities creator)
     {
@@ -54,7 +54,7 @@ public class DbContextBuilder<T> where T : DbContext
     /// Populates the specified DbSet with the provided entities.
     /// </summary>
     /// <param name="entities">The entities to populate the database with</param>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     /// <exception cref="ArgumentNullException">entities is null</exception>
     /// <exception cref="ArgumentException">entities contains a null item</exception>
     /// <exception cref="ArgumentException">entities contains a string</exception>
@@ -80,7 +80,7 @@ public class DbContextBuilder<T> where T : DbContext
     /// <summary>
     /// Populates the specified DbSet with the provided entities.
     /// </summary>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     /// <param name="entities">The entities to populate the database with</param>
     /// <exception cref="ArgumentNullException">entities is null</exception>
     /// <exception cref="ArgumentException">entities contains a null item</exception>
@@ -119,7 +119,7 @@ public class DbContextBuilder<T> where T : DbContext
     /// </summary>
     /// <param name="count">The number of items to create</param>
     /// <typeparam name="TEntity">The type of entity to create</typeparam>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     /// <exception cref="ArgumentOutOfRangeException">count is less than 1</exception>
     public DbContextBuilder<T> SeedWithRandom<TEntity>(int count) where TEntity : class
     {
@@ -144,7 +144,7 @@ public class DbContextBuilder<T> where T : DbContext
     /// <param name="count">The number of items to create</param>
     /// <param name="func">A function that takes a TEntity and returns an updated TEntity</param>
     /// <typeparam name="TEntity">The type of entity to create</typeparam>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     /// <exception cref="ArgumentOutOfRangeException">count is less than 1</exception>
     /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
     public DbContextBuilder<T> SeedWithRandom<TEntity>(int count, Func<TEntity, TEntity> func) where TEntity : class
@@ -176,7 +176,7 @@ public class DbContextBuilder<T> where T : DbContext
     /// <param name="count">The number of items to create</param>
     /// <param name="func">A function that takes a TEntity and the index number of the entity and returns an updated TEntity</param>
     /// <typeparam name="TEntity">The type of entity to create</typeparam>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     /// <exception cref="ArgumentOutOfRangeException">count is less than 1</exception>
     /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
     public DbContextBuilder<T> SeedWithRandom<TEntity>(int count, Func<TEntity, int, TEntity> func) where TEntity : class
@@ -203,10 +203,15 @@ public class DbContextBuilder<T> where T : DbContext
 
 
     /// <summary>
-    /// Creates a new instance of T seeded with specified data.
+    /// Creates a new instance of <typeparamref name="T"/> seeded with the configured data.
     /// </summary>
-    /// <returns>instance of {T}</returns>
-    /// <exception cref="InvalidOperationException">No database provider has been configured.</exception>
+    /// <returns>A new instance of <typeparamref name="T"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// <typeparamref name="T"/> does not have a constructor that accepts
+    /// (<see cref="System.Data.Common.DbConnection"/>, <see cref="bool"/>), so the in-memory backing database
+    /// could not be initialized. See the wrapped <see cref="Exception.InnerException"/> for
+    /// the underlying <see cref="MissingMethodException"/>.
+    /// </exception>
     public T Build()
     {
         var contextCreator = CreateDbContext ?? new EffortDbContextCreator();
@@ -230,10 +235,16 @@ public class DbContextBuilder<T> where T : DbContext
 
 
     /// <summary>
-    /// Creates a new instance of T seeded with specified data asynchronously.
+    /// Creates a new instance of <typeparamref name="T"/> seeded with the configured data
+    /// asynchronously.
     /// </summary>
-    /// <returns>instance of {T}</returns>
-    /// <exception cref="InvalidOperationException">No database provider has been configured.</exception>
+    /// <returns>A new instance of <typeparamref name="T"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// <typeparamref name="T"/> does not have a constructor that accepts
+    /// (<see cref="System.Data.Common.DbConnection"/>, <see cref="bool"/>), so the in-memory backing database
+    /// could not be initialized. See the wrapped <see cref="Exception.InnerException"/> for
+    /// the underlying <see cref="MissingMethodException"/>.
+    /// </exception>
     public async Task<T> BuildAsync()
     {
         var contextCreator = CreateDbContext ?? new EffortDbContextCreator();

--- a/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilderAutoFixtureExtensions.cs
+++ b/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilderAutoFixtureExtensions.cs
@@ -11,7 +11,7 @@ public static class DbContextBuilderAutoFixtureExtensions
     /// <summary>
     /// Tell DbContextBuilder to use AutoFixture to create random entities.
     /// </summary>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <c>null</c>.</exception>
     public static DbContextBuilder<T> UseAutoFixture<T>(this DbContextBuilder<T> builder) where T : DbContext
     {

--- a/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilderEffortExtensions.cs
+++ b/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilderEffortExtensions.cs
@@ -11,7 +11,7 @@ public static class DbContextBuilderEffortExtensions
     /// <summary>
     /// Instructs the builder to use Effort as the in-memory database provider.
     /// </summary>
-    /// <returns><see cref="DbContextBuilder{T}"></see></returns>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
     /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <c>null</c>.</exception>
     public static DbContextBuilder<T> UseEffort<T>(this DbContextBuilder<T> builder) where T : DbContext
     {

--- a/src/Wolfgang.DbContextBuilder-EF6/EffortDbContextCreator.cs
+++ b/src/Wolfgang.DbContextBuilder-EF6/EffortDbContextCreator.cs
@@ -37,14 +37,12 @@ internal sealed class EffortDbContextCreator : ICreateDbContext
     /// <exception cref="MissingMethodException">
     /// The specified <typeparamref name="TDbContext"/> type does not have a constructor
     /// that accepts (<see cref="DbConnection"/>, <see cref="bool"/>). Thrown by
-    /// <see cref="Activator.CreateInstance(Type, object[])"/>.
+    /// <see cref="Activator.CreateInstance(Type, object[])"/> and propagated to the
+    /// caller — <see cref="DbContextBuilder{T}.Build"/> /
+    /// <see cref="DbContextBuilder{T}.BuildAsync"/> do not wrap this exception, because
+    /// the call to <c>CreateDbContext&lt;T&gt;()</c> happens before <c>InitializeDatabase</c>
+    /// (the method whose <c>try/catch</c> performs the only wrap in the builder).
     /// </exception>
-    /// <remarks>
-    /// <see cref="DbContextBuilder{T}.BuildAsync"/> wraps the underlying
-    /// <see cref="MissingMethodException"/> in an <see cref="InvalidOperationException"/>
-    /// with a more actionable message; callers using the builder should expect that wrapped
-    /// form, not the raw exception thrown here.
-    /// </remarks>
     public TDbContext CreateDbContext<TDbContext>() where TDbContext : DbContext
     {
         return (TDbContext)Activator.CreateInstance

--- a/src/Wolfgang.DbContextBuilder-EF6/EffortDbContextCreator.cs
+++ b/src/Wolfgang.DbContextBuilder-EF6/EffortDbContextCreator.cs
@@ -34,10 +34,17 @@ internal sealed class EffortDbContextCreator : ICreateDbContext
     /// </summary>
     /// <typeparam name="TDbContext">The type of DbContext to create.</typeparam>
     /// <returns>A new instance of <typeparamref name="TDbContext"/>.</returns>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="MissingMethodException">
     /// The specified <typeparamref name="TDbContext"/> type does not have a constructor
-    /// that accepts (<see cref="DbConnection"/>, <see cref="bool"/>).
+    /// that accepts (<see cref="DbConnection"/>, <see cref="bool"/>). Thrown by
+    /// <see cref="Activator.CreateInstance(Type, object[])"/>.
     /// </exception>
+    /// <remarks>
+    /// <see cref="DbContextBuilder{T}.BuildAsync"/> wraps the underlying
+    /// <see cref="MissingMethodException"/> in an <see cref="InvalidOperationException"/>
+    /// with a more actionable message; callers using the builder should expect that wrapped
+    /// form, not the raw exception thrown here.
+    /// </remarks>
     public TDbContext CreateDbContext<TDbContext>() where TDbContext : DbContext
     {
         return (TDbContext)Activator.CreateInstance

--- a/src/Wolfgang.DbContextBuilder-EF6/ICreateDbContext.cs
+++ b/src/Wolfgang.DbContextBuilder-EF6/ICreateDbContext.cs
@@ -9,8 +9,13 @@ namespace Wolfgang.DbContextBuilderEF6;
 /// instances, etc.) and must release it from <see cref="IDisposable.Dispose"/>.
 /// </summary>
 /// <remarks>
-/// Implementations are expected to be disposed by the caller. The contexts they return are
-/// owned by the caller and disposed independently of the creator itself.
+/// In the current builder topology the implementation is constructed and owned by
+/// <see cref="DbContextBuilder{T}"/> itself — consumers do not typically hold or dispose
+/// the creator directly. The <see cref="IDisposable"/> contract is on the interface so
+/// that custom implementations registered via a future public extension point can still
+/// release resources deterministically when the builder is disposed. <see cref="DbContext"/>
+/// instances returned by <see cref="CreateDbContext{TDbContext}"/> are owned by the caller
+/// and disposed independently of the creator.
 /// </remarks>
 public interface ICreateDbContext : IDisposable
 {

--- a/src/Wolfgang.DbContextBuilder-EF6/ICreateDbContext.cs
+++ b/src/Wolfgang.DbContextBuilder-EF6/ICreateDbContext.cs
@@ -4,8 +4,14 @@ using System.Data.Entity;
 namespace Wolfgang.DbContextBuilderEF6;
 
 /// <summary>
-/// Provides an API to create instances of <see cref="DbContext"/> for testing.
+/// Provides an API to create instances of <see cref="DbContext"/> for testing. Implementations
+/// own any test-only infrastructure they allocate (in-memory connections, AutoFixture
+/// instances, etc.) and must release it from <see cref="IDisposable.Dispose"/>.
 /// </summary>
+/// <remarks>
+/// Implementations are expected to be disposed by the caller. The contexts they return are
+/// owned by the caller and disposed independently of the creator itself.
+/// </remarks>
 public interface ICreateDbContext : IDisposable
 {
     /// <summary>

--- a/src/Wolfgang.DbContextBuilder-EF6/ICreateRandomEntities.cs
+++ b/src/Wolfgang.DbContextBuilder-EF6/ICreateRandomEntities.cs
@@ -13,7 +13,8 @@ public interface ICreateRandomEntities
     /// </summary>
     /// <param name="count">The number of entities to create</param>
     /// <typeparam name="TEntity">The type of entity to create</typeparam>
-    /// <returns>An IEnumerable{TEntity}</returns>
+    /// <returns>An <see cref="IEnumerable{T}"/> of <typeparamref name="TEntity"/>.</returns>
+    /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="count"/> is less than 1.</exception>
     IEnumerable<TEntity> CreateRandomEntities<TEntity>(int count) where TEntity : class;
 
 }


### PR DESCRIPTION
## Summary

Fix stale, misleading, or malformed XML doc comments across the Core and classic-EF6 projects. No code behavior changes.

Highlights:

- **Exception docs aligned with reality**: EF6 `EffortDbContextCreator` was claiming `InvalidOperationException` where `Activator.CreateInstance` actually throws `MissingMethodException`. EF6 `DbContextBuilder.Build`/`BuildAsync` was claiming "No database provider configured" — that path can't fire because the code defaults to `EffortDbContextCreator`. Core `BuildAsync` was claiming `NotSupportedException` — never thrown.
- **Truncated comment fixed** in `AutoFixtureRandomEntityCreator` (Core + EF6).
- **Stale method reference** in `SqliteForMsSqlServerModelCustomizer` `<remarks>` (referenced nonexistent `UseSqliteForMsSqlServerModelCustomizer`) replaced with `<see cref>` to the real `UseSqliteForMsSqlServer`.
- **Bare exception tags** in `SqliteModelCustomizer` now name what triggers them.
- **Literal `IEnumerable{T}` in `<returns>`** replaced with proper `<see cref>` + `<typeparamref>` in `ICreateRandomEntities` and `AutoFixtureRandomEntityCreator` (Core + EF6). Adds missing `<exception>` for `ArgumentOutOfRangeException`.
- **`<see cref="X"></see>` → `<see cref="X" />`** — 19 occurrences across 6 files normalized to the canonical self-closing form.

## Test plan

- [x] `dotnet build -c Release` — clean
- [ ] CI passes