### PR TITLE
feat: SeedWith(TEntity) singleton overload + DefaultValueMap doc (review items 9, 10)

### DIFF
--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
@@ -131,6 +131,39 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
 
 
     /// <summary>
+    /// Populates the specified DbSet with a single entity. Equivalent to calling the
+    /// <c>params</c>-array overload with one element, but avoids the per-call allocation
+    /// of a one-element array — useful in tests that seed many single rows.
+    /// </summary>
+    /// <param name="entity">The entity to populate the database with.</param>
+    /// <returns>The builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="entity"/> is null.</exception>
+    /// <exception cref="ArgumentException"><typeparamref name="TEntity"/> is <see cref="string"/>.</exception>
+    public DbContextBuilder<T> SeedWith<TEntity>(TEntity entity)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        if (typeof(TEntity) == typeof(string))
+        {
+            throw new ArgumentException("The type of TEntity cannot be string", nameof(entity));
+        }
+
+        if (entity is IEnumerable<object> sequence)
+        {
+            _seedData.AddRange(sequence);
+        }
+        else
+        {
+            _seedData.Add(entity);
+        }
+
+        return this;
+    }
+
+
+
+    /// <summary>
     /// Populates the specified DbSet with random entities of type TEntity.
     /// </summary>
     /// <param name="count">The number of items to create</param>

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
@@ -138,15 +138,18 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// <param name="entity">The entity to populate the database with.</param>
     /// <returns>The builder, for chaining.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="entity"/> is null.</exception>
-    /// <exception cref="ArgumentException"><typeparamref name="TEntity"/> is <see cref="string"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="entity"/> is a <see cref="string"/> instance (matches the
+    /// <c>params</c> overload's rejection regardless of how <typeparamref name="TEntity"/> was inferred).</exception>
     public DbContextBuilder<T> SeedWith<TEntity>(TEntity entity)
         where TEntity : class
     {
         ArgumentNullException.ThrowIfNull(entity);
 
-        if (typeof(TEntity) == typeof(string))
+        // Reject by runtime type, not just TEntity, so `SeedWith<object>("...")` is still
+        // caught (matches the params overload's `case string:` arm).
+        if (entity is string)
         {
-            throw new ArgumentException("The type of TEntity cannot be string", nameof(entity));
+            throw new ArgumentException("One of the entities passed in is of type string", nameof(entity));
         }
 
         if (entity is IEnumerable<object> sequence)

--- a/src/Wolfgang.DbContextBuilder-Core/SqliteModelCustomizer.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/SqliteModelCustomizer.cs
@@ -80,8 +80,11 @@ public class SqliteModelCustomizer : ModelCustomizer
     /// value to replace it with.
     /// </summary>
     /// <remarks>
-    /// Examples of a default values that may need to be replaced it getdate() and newid() which would
-    /// be replaced with datetime('now') and lower(hex(randomblob(16))) respectively.
+    /// Examples of default values that may need to be replaced are <c>getdate()</c> and
+    /// <c>newid()</c>, which would be replaced with <c>datetime('now')</c> and
+    /// <c>lower(hex(randomblob(16)))</c> respectively. Key lookups are case-insensitive
+    /// (<see cref="StringComparer.OrdinalIgnoreCase"/>) so variant spellings produced by
+    /// different EF versions match the same replacement entry.
     /// </remarks>
     public IDictionary<string, string> DefaultValueMap { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilder.cs
@@ -115,6 +115,42 @@ public class DbContextBuilder<T> where T : DbContext
 
 
     /// <summary>
+    /// Populates the specified DbSet with a single entity. Equivalent to calling the
+    /// <c>params</c>-array overload with one element, but avoids the per-call allocation
+    /// of a one-element array — useful in tests that seed many single rows.
+    /// </summary>
+    /// <param name="entity">The entity to populate the database with.</param>
+    /// <returns>The builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="entity"/> is null.</exception>
+    /// <exception cref="ArgumentException"><typeparamref name="TEntity"/> is <see cref="string"/>.</exception>
+    public DbContextBuilder<T> SeedWith<TEntity>(TEntity entity)
+        where TEntity : class
+    {
+        if (entity == null)
+        {
+            throw new ArgumentNullException(nameof(entity));
+        }
+
+        if (typeof(TEntity) == typeof(string))
+        {
+            throw new ArgumentException("The type of TEntity cannot be string", nameof(entity));
+        }
+
+        if (entity is IEnumerable<object> sequence)
+        {
+            _seedData.AddRange(sequence);
+        }
+        else
+        {
+            _seedData.Add(entity);
+        }
+
+        return this;
+    }
+
+
+
+    /// <summary>
     /// Populates the specified DbSet with random entities of type TEntity.
     /// </summary>
     /// <param name="count">The number of items to create</param>

--- a/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilder.cs
@@ -122,7 +122,8 @@ public class DbContextBuilder<T> where T : DbContext
     /// <param name="entity">The entity to populate the database with.</param>
     /// <returns>The builder, for chaining.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="entity"/> is null.</exception>
-    /// <exception cref="ArgumentException"><typeparamref name="TEntity"/> is <see cref="string"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="entity"/> is a <see cref="string"/> instance (matches the
+    /// <c>params</c> overload's rejection regardless of how <typeparamref name="TEntity"/> was inferred).</exception>
     public DbContextBuilder<T> SeedWith<TEntity>(TEntity entity)
         where TEntity : class
     {
@@ -131,9 +132,11 @@ public class DbContextBuilder<T> where T : DbContext
             throw new ArgumentNullException(nameof(entity));
         }
 
-        if (typeof(TEntity) == typeof(string))
+        // Reject by runtime type, not just TEntity, so `SeedWith<object>("...")` is still
+        // caught (matches the params overload's `case string:` arm).
+        if (entity is string)
         {
-            throw new ArgumentException("The type of TEntity cannot be string", nameof(entity));
+            throw new ArgumentException("One of the entities passed in is of type string", nameof(entity));
         }
 
         if (entity is IEnumerable<object> sequence)

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbContextBuilderTestsBase.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbContextBuilderTestsBase.cs
@@ -666,15 +666,18 @@ public abstract class DbContextBuilderTestsBase
     /// with the restriction that the object must be classes and string is a class
     /// </remarks>
     [Fact]
-    public void SeedWith_params_when_passed_an_array_of_strings_throws_ArgumentException()
+    public void SeedWith_when_TEntity_is_string_throws_ArgumentException()
     {
         // Arrange
         var sut = CreateDbContextBuilder();
 
-
-        // Act & Assert
-        var ex = Assert.Throws<ArgumentException>(() => sut.SeedWith("Invalid value"));
-        Assert.Equal("entities", ex.ParamName);
+        // Act & Assert — the single-string call now resolves to the singleton overload
+        // (added in the SeedWith singleton PR) which raises ArgumentException with
+        // paramName "entity"; the params overload still raises it for string[] with
+        // paramName "entities". Assert at the Exception level so the test is resilient
+        // to overload-resolution choices.
+        Assert.Throws<ArgumentException>(() => sut.SeedWith("Invalid value"));
+        Assert.Throws<ArgumentException>(() => sut.SeedWith(new[] { "Invalid value" }));
     }
 
 
@@ -1192,5 +1195,65 @@ public abstract class DbContextBuilderTestsBase
 
         // Assert
         Assert.NotNull(context);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that the new SeedWith(TEntity) singleton overload — which exists to skip the
+    /// one-element array allocation of the params overload — actually inserts the row. Uses
+    /// the InMemory provider explicitly to side-step relational FK constraints under SQLite.
+    /// </summary>
+    [Fact]
+    public async Task SeedWith_singleton_overload_seeds_the_entity()
+    {
+        // Arrange
+        using var sut = new DbContextBuilder<AdventureWorksDbContext>();
+        var address = new Address
+        {
+            AddressId = 999,
+            AddressLine1 = "1 Singleton Way",
+            City = "Singletontown",
+            StateProvinceId = 1,
+            PostalCode = "00001",
+            Rowguid = Guid.NewGuid(),
+            ModifiedDate = DateTime.UtcNow
+        };
+
+        // Act — note: no array literal, no params expansion
+        await using var context = await sut.UseInMemory().SeedWith(address).BuildAsync();
+
+        // Assert
+        var row = context.Addresses.SingleOrDefault(a => a.AddressId == 999);
+        Assert.NotNull(row);
+        Assert.Equal("1 Singleton Way", row!.AddressLine1);
+    }
+
+
+
+    /// <summary>
+    /// SeedWith(TEntity) must reject null with ArgumentNullException so callers do not
+    /// silently insert nothing.
+    /// </summary>
+    [Fact]
+    public void SeedWith_singleton_overload_when_entity_is_null_throws()
+    {
+        using var sut = CreateDbContextBuilder();
+
+        Assert.Throws<ArgumentNullException>(() => sut.SeedWith((Address)null!));
+    }
+
+
+
+    /// <summary>
+    /// SeedWith(TEntity) must reject string at the type level just like the params overload,
+    /// so the two overloads behave consistently.
+    /// </summary>
+    [Fact]
+    public void SeedWith_singleton_overload_when_TEntity_is_string_throws()
+    {
+        using var sut = CreateDbContextBuilder();
+
+        Assert.Throws<ArgumentException>(() => sut.SeedWith("not an entity"));
     }
 }

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbContextBuilderTestsBase.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbContextBuilderTestsBase.cs
@@ -1256,4 +1256,20 @@ public abstract class DbContextBuilderTestsBase
 
         Assert.Throws<ArgumentException>(() => sut.SeedWith("not an entity"));
     }
+
+
+
+    /// <summary>
+    /// Regression: when the caller widens TEntity to <see cref="object"/> the static
+    /// `typeof(TEntity) == typeof(string)` check (the original guard) would pass through
+    /// and silently seed the string. The current guard uses a runtime `entity is string`
+    /// check and must still reject.
+    /// </summary>
+    [Fact]
+    public void SeedWith_singleton_overload_when_TEntity_is_widened_to_object_still_rejects_string()
+    {
+        using var sut = CreateDbContextBuilder();
+
+        Assert.Throws<ArgumentException>(() => sut.SeedWith<object>("not an entity"));
+    }
 }


### PR DESCRIPTION
## Summary

Two small additive surface changes from the code review:

### `SeedWith<TEntity>(TEntity entity)` singleton overload

Adds a single-entity overload to both the EF Core and classic-EF6 `DbContextBuilder<T>`. The existing `params TEntity[]` overload allocates a one-element array when callers pass a single entity; the new overload bypasses that for tests that seed many single rows in tight loops.

### `DefaultValueMap` docstring

`SqliteModelCustomizer.DefaultValueMap` is backed by `Dictionary<string,string>` using `StringComparer.OrdinalIgnoreCase`. The `<remarks>` now mentions that explicitly so callers can predict the lookup behaviour without reading the initializer.

## Test changes — please review

Adding the singleton overload shifts overload resolution for any call with a single argument from the params overload to the new singleton overload, including:

- `sut.SeedWith(myEntity)` — now uses the singleton (the intended ergonomic win)
- `sut.SeedWith("string")` — now uses the singleton (paramName changes from `"entities"` to `"entity"`)

That broke the pre-existing test `SeedWith_params_when_passed_an_array_of_strings_throws_ArgumentException` whose final assertion was `Assert.Equal("entities", ex.ParamName)`. Two changes to that test:

1. Rename to `SeedWith_when_TEntity_is_string_throws_ArgumentException` — the original name claimed "array" but the call was a single string.
2. Drop the brittle ParamName assertion and cover BOTH overloads explicitly (singleton via `sut.SeedWith("...")`, params via `sut.SeedWith(new[] { "..." })`).

Three new tests cover the singleton path: seeds-the-entity (asserts the row lands via InMemory query), null entity throws, string TEntity throws.

223 tests pass on net10.0.

## Test plan

- [x] `dotnet build -c Release` — clean
- [x] `dotnet test` — 223 passed
- [ ] CI