### PR TITLE
perf: cache TDbContext ctor + reduce TableRenaming alloc + typeof match (review items 11, 12, 31)

### DIFF
--- a/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
@@ -33,6 +33,7 @@
 	 </PropertyGroup>
 	 <ItemGroup>
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\AutoFixtureRandomEntityCreator.cs" Link="AutoFixtureRandomEntityCreator.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextActivator.cs" Link="DbContextActivator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilder.cs" Link="DbContextBuilder.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilderAutoFixtureExtensions.cs" Link="DbContextBuilderAutoFixtureExtensions.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilderSqliteExtensions.cs" Link="DbContextBuilderSqliteExtensions.cs" />

--- a/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
@@ -33,6 +33,7 @@
 	</PropertyGroup>
 	 <ItemGroup>
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\AutoFixtureRandomEntityCreator.cs" Link="AutoFixtureRandomEntityCreator.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextActivator.cs" Link="DbContextActivator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilder.cs" Link="DbContextBuilder.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilderAutoFixtureExtensions.cs" Link="DbContextBuilderAutoFixtureExtensions.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilderSqliteExtensions.cs" Link="DbContextBuilderSqliteExtensions.cs" />

--- a/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
@@ -33,6 +33,7 @@
 	</PropertyGroup>
 	 <ItemGroup>
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\AutoFixtureRandomEntityCreator.cs" Link="AutoFixtureRandomEntityCreator.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextActivator.cs" Link="DbContextActivator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilder.cs" Link="DbContextBuilder.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilderAutoFixtureExtensions.cs" Link="DbContextBuilderAutoFixtureExtensions.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilderSqliteExtensions.cs" Link="DbContextBuilderSqliteExtensions.cs" />

--- a/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
@@ -33,6 +33,7 @@
 	 </PropertyGroup>
 	 <ItemGroup>
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\AutoFixtureRandomEntityCreator.cs" Link="AutoFixtureRandomEntityCreator.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextActivator.cs" Link="DbContextActivator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilder.cs" Link="DbContextBuilder.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilderAutoFixtureExtensions.cs" Link="DbContextBuilderAutoFixtureExtensions.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilderSqliteExtensions.cs" Link="DbContextBuilderSqliteExtensions.cs" />

--- a/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
@@ -33,6 +33,7 @@
 	 </PropertyGroup>
 	 <ItemGroup>
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\AutoFixtureRandomEntityCreator.cs" Link="AutoFixtureRandomEntityCreator.cs" />
+	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextActivator.cs" Link="DbContextActivator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilder.cs" Link="DbContextBuilder.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilderAutoFixtureExtensions.cs" Link="DbContextBuilderAutoFixtureExtensions.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\DbContextBuilderSqliteExtensions.cs" Link="DbContextBuilderSqliteExtensions.cs" />

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextActivator.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextActivator.cs
@@ -1,0 +1,60 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolfgang.DbContextBuilderCore;
+
+/// <summary>
+/// Caches a compiled constructor delegate per <typeparamref name="TDbContext"/> so that
+/// each <c>BuildAsync</c> call does not pay the reflection cost of
+/// <see cref="Activator.CreateInstance(Type, object[])"/>. Hot in test suites that build
+/// many contexts.
+/// </summary>
+/// <typeparam name="TDbContext">The concrete <see cref="DbContext"/> type to construct.</typeparam>
+/// <remarks>
+/// The first call for a given <typeparamref name="TDbContext"/> resolves the ctor and
+/// compiles a delegate that calls it; subsequent calls invoke the delegate directly.
+/// The cache field is static-per-closed-generic, so there is no concurrency primitive
+/// needed — the runtime initializes it at most once per type.
+/// </remarks>
+internal static class DbContextActivator<TDbContext>
+    where TDbContext : DbContext
+{
+    private static readonly Func<DbContextOptions<TDbContext>, TDbContext> _factory = BuildFactory();
+
+
+
+    /// <summary>
+    /// Instantiates a <typeparamref name="TDbContext"/> using the cached compiled ctor.
+    /// </summary>
+    /// <param name="options">The configured <see cref="DbContextOptions{TContext}"/>.</param>
+    /// <returns>A new <typeparamref name="TDbContext"/> instance.</returns>
+    public static TDbContext Create(DbContextOptions<TDbContext> options) => _factory(options);
+
+
+
+    private static Func<DbContextOptions<TDbContext>, TDbContext> BuildFactory()
+    {
+        var type = typeof(TDbContext);
+        var ctor = type.GetConstructor
+        (
+            BindingFlags.Public | BindingFlags.Instance,
+            binder: null,
+            types: new[] { typeof(DbContextOptions<TDbContext>) },
+            modifiers: null
+        );
+
+        if (ctor is null)
+        {
+            // Fall back to Activator.CreateInstance so the call still works (and
+            // throws a familiar MissingMethodException) for types that take
+            // DbContextOptions (non-generic) or other shapes. Same allocation cost
+            // as before, but only on the first call for this TDbContext.
+            return options => (TDbContext)Activator.CreateInstance(type, options)!;
+        }
+
+        var optionsParam = Expression.Parameter(typeof(DbContextOptions<TDbContext>), "options");
+        var newExpr = Expression.New(ctor, optionsParam);
+        return Expression.Lambda<Func<DbContextOptions<TDbContext>, TDbContext>>(newExpr, optionsParam).Compile();
+    }
+}

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderSqliteExtensions.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderSqliteExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Wolfgang.DbContextBuilderCore;
@@ -66,10 +67,10 @@ public static class DbContextBuilderSqliteExtensions
             builder.ServiceCollection.Remove(descriptor);
         }
 
-        // Avoid registering EF services multiple times
-        if (!builder.ServiceCollection.Any(sd =>
-                sd.ServiceType.FullName != null &&
-                sd.ServiceType.FullName.Contains("Microsoft.EntityFrameworkCore.Sqlite.SqliteOptionsExtension")))
+        // Avoid registering EF services multiple times. Use a typeof check on the
+        // SQLite options extension type rather than matching its FullName as a string
+        // (which silently breaks if EF renames or moves the type).
+        if (!builder.ServiceCollection.Any(sd => sd.ServiceType == typeof(SqliteOptionsExtension)))
         {
             builder.ServiceCollection.AddEntityFrameworkSqlite();
         }

--- a/src/Wolfgang.DbContextBuilder-Core/InMemoryDbContextCreator.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/InMemoryDbContextCreator.cs
@@ -16,7 +16,6 @@ internal class InMemoryDbContextCreator : ICreateDbContext
     public Task<TDbContext> CreateDbContextAsync<TDbContext>(DbContextOptionsBuilder<TDbContext> optionsBuilder) where TDbContext : DbContext
     {
         optionsBuilder.UseInMemoryDatabase(_databaseName);
-        var options = optionsBuilder.Options;
-        return Task.FromResult((TDbContext)Activator.CreateInstance(typeof(TDbContext), options)!);
+        return Task.FromResult(DbContextActivator<TDbContext>.Create(optionsBuilder.Options));
     }
 }

--- a/src/Wolfgang.DbContextBuilder-Core/SqliteDbContextCreator.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/SqliteDbContextCreator.cs
@@ -29,12 +29,8 @@ internal sealed class SqliteDbContextCreator : ICreateDbContext, IDisposable
     /// <inheritdoc />
     public Task<TDbContext> CreateDbContextAsync<TDbContext>(DbContextOptionsBuilder<TDbContext> optionsBuilder) where TDbContext : DbContext
     {
-
         optionsBuilder.UseSqlite(_connection);
-
-        var options = optionsBuilder.Options;
-
-        return Task.FromResult((TDbContext)Activator.CreateInstance(typeof(TDbContext), options)!);
+        return Task.FromResult(DbContextActivator<TDbContext>.Create(optionsBuilder.Options));
     }
 
 

--- a/src/Wolfgang.DbContextBuilder-Core/SqliteModelCustomizer.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/SqliteModelCustomizer.cs
@@ -46,10 +46,17 @@ public class SqliteModelCustomizer : ModelCustomizer
             {
                 var schemaPrefix = t.SchemaName ?? "dbo";
 
-                // Avoid recursive renaming
-                return t.TableName.StartsWith($"{schemaPrefix}_", StringComparison.OrdinalIgnoreCase)
-                    ? t.TableName // Table has already been renamed so just return it
-                    : $"{schemaPrefix}_{t.TableName}"; // Rename table by prefixing schema name
+                // Avoid recursive renaming. Check without allocating an interpolated
+                // "{prefix}_" probe string per entity type — compare the prefix substring
+                // directly then verify the separator character.
+                if (t.TableName.Length > schemaPrefix.Length
+                    && t.TableName[schemaPrefix.Length] == '_'
+                    && t.TableName.StartsWith(schemaPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return t.TableName; // already renamed
+                }
+
+                return $"{schemaPrefix}_{t.TableName}";
             };
         set => _overrideTableRenaming = value ?? throw new ArgumentNullException(nameof(value));
     }


### PR DESCRIPTION
## Summary

Three perf nibbles surfaced by the review:

1. **`DbContextActivator<TDbContext>`** — cache a compiled ctor delegate per closed generic so each `BuildAsync` does not pay the `Activator.CreateInstance` reflection cost. Hot in test suites that build many contexts.
2. **`OverrideTableRenaming` default lambda** — drop the per-entity-type `$"{prefix}_"` interpolation; compare prefix substring + separator char directly.
3. **SQLite-already-registered check** — replace `sd.ServiceType.FullName.Contains("…SqliteOptionsExtension")` with `sd.ServiceType == typeof(SqliteOptionsExtension)`. No silent breakage on EF type moves.

`DbContextActivator.cs` linked into all 5 EF Core shims via the existing `<Compile Include>` pattern.

## Test plan

- [x] `dotnet build -c Release` — clean
- [x] `dotnet test` — 214 passed
- [ ] CI