### PR TITLE
test: rename for convention + strengthen log-buffer assertion (review items 21, 33)

### DIFF
--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/AutoFixtureRandomEntityCreatorTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/AutoFixtureRandomEntityCreatorTests.cs
@@ -20,7 +20,7 @@ public class AutoFixtureRandomEntityCreatorTests : ICreateRandomEntitiesTestsBas
 	/// Verifies that the Fixture property is not null
 	/// </summary>
 	[Fact]
-	public void Property_Fixture_is_not_null()
+	public void Fixture_when_default_ctor_is_used_is_not_null()
 	{
 		// Arrange
 		var sut = new AutoFixtureRandomEntityCreator();
@@ -48,7 +48,7 @@ public class AutoFixtureRandomEntityCreatorTests : ICreateRandomEntitiesTestsBas
 	/// Verifies that the value passed into the constructor is assigned to the Fixture property
 	/// </summary>
 	[Fact]
-	public void Sets_Fixture_property_to_the_value_passed_into_ctor()
+	public void Ctor_when_passed_a_fixture_assigns_it_to_the_Fixture_property()
 	{
 		// Arrange
 		var fixture = new Fixture();

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbContextBuilderTestsBase.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbContextBuilderTestsBase.cs
@@ -1135,8 +1135,15 @@ public abstract class DbContextBuilderTestsBase
         await sut.BuildAsync();
 
 
-        // Assert
-        Assert.True(buffer.Length > 0, "Buffer length was expected to be greater than 0");
+        // Assert — the LogTo callback the test wired in must have received something
+        // (EF emits at least one log line when initializing the connection). Asserting
+        // NotEmpty on the materialized string gives a clearer failure message than the
+        // previous `buffer.Length > 0` numeric check, and asserting that the log
+        // contains a known EF marker pins the test to "EF actually logged via our
+        // callback" rather than "the buffer happens to be non-zero for any reason".
+        var log = buffer.ToString();
+        Assert.NotEmpty(log);
+        Assert.Contains("Microsoft.EntityFrameworkCore", log, StringComparison.Ordinal);
     }
 
 


### PR DESCRIPTION
## Summary

- Rename two `AutoFixtureRandomEntityCreator` tests to follow the `MethodUnderTest_when_condition_expected_result` convention from CLAUDE.md.
- Replace a brittle `Assert.True(buffer.Length > 0, …)` assertion with `Assert.NotEmpty(log) + Assert.Contains("Microsoft.EntityFrameworkCore", log, …)`. The substring check pins the test to "EF actually logged via our callback" rather than "the buffer happens to be non-zero", giving a clearer failure when the wiring breaks.

The broader test-naming-convention sweep across `DbContextBuilderTestsBase.cs` is deferred — that file is 1100+ lines and the rename would dominate the diff. This PR scopes to the two most egregious cases.

## Test plan

- [x] `dotnet build -c Release` — clean
- [x] `dotnet test` — 214 passed
- [ ] CI