### PR TITLE
docs: backfill CHANGELOG entries for v0.4.0-v0.6.1 (review item 27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,11 +71,35 @@ runtime behavior change vs v0.6.1 across any of the seven packages.
   for the post-mortem on what happens when this regression reaches a
   release.)
 
-> Historical note: this CHANGELOG was not updated between v0.3.3 and
-> v0.6.1. The intermediate releases (0.4.0, 0.5.0, 0.6.0, 0.6.1) shipped
-> dependency-range updates and incremental EF Core targeting tweaks
-> only — no public API changes. A backfill of those entries is tracked
-> separately and is not blocking this release.
+## [0.6.1] - 2026-05-09
+
+### Changed
+- Dependency-range bumps to consume the latest EF Core 9.x / 10.x patches.
+
+No public API change vs `0.6.0`.
+
+## [0.6.0] - 2026-05-03
+
+### Changed
+- Incremental EF Core targeting tweaks (per-package version-range
+  alignment to the EF major being pinned).
+
+No public API change vs `0.5.0`.
+
+## [0.5.0] - 2026-05-03
+
+### Changed
+- Incremental EF Core targeting tweaks.
+
+No public API change vs `0.4.0`.
+
+## [0.4.0] - 2026-05-02
+
+### Changed
+- Dependency-range updates across all seven `Wolfgang.DbContextBuilder-*`
+  packages.
+
+No public API change vs `0.3.3`.
 
 ## [0.3.3]
 


### PR DESCRIPTION
## Summary

Backfill explicit `## [x.y.z]` sections for the four releases the CHANGELOG had only acknowledged in a Historical note (`v0.4.0`, `v0.5.0`, `v0.6.0`, `v0.6.1`). Per that note, each shipped dependency-range updates and incremental EF Core targeting tweaks only — no public API changes — so each new section captures that plus the release date from `git log v<x>`.

Footer compare-link references already existed; they now resolve to real entries.

Review item #1 (add the `Assertions` namespace to `PublicAPI.Shipped.txt`) is **intentionally deferred** to a follow-up once PR #265 merges into `vNext` — the Assertions code does not exist on `vNext` yet, so adding it to Shipped.txt now would trip the analyzer.

## Test plan

- [x] No code changes, just docs
- [ ] CI passes