### PR TITLE
fix: SeedWith(TEntity) singleton must reject string elements (follow-up to #270)

### DIFF
--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
@@ -154,12 +154,11 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
 
         if (entity is IEnumerable<object> sequence)
         {
-            // Walk the sequence so a List<string> (or any IEnumerable that wraps strings)
-            // is rejected element-by-element, matching the per-item check the params
-            // overload performs in its foreach. Without this, the runtime
-            // IEnumerable<object> cast (which works because IEnumerable<T> is covariant
-            // in T for reference types) would let a List<string> through as silent
-            // seed data.
+            // Walk the sequence so a List<string> (or any IEnumerable wrapping strings) is
+            // rejected element-by-element, matching the per-item check the params overload
+            // performs. Buffer first so the failing call leaves `_seedData` untouched
+            // (atomic w.r.t. seed state).
+            var buffer = new List<object>();
             foreach (var item in sequence)
             {
                 if (item is string)
@@ -167,8 +166,10 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
                     throw new ArgumentException("One of the entities passed in is of type string", nameof(entity));
                 }
 
-                _seedData.Add(item);
+                buffer.Add(item);
             }
+
+            _seedData.AddRange(buffer);
         }
         else
         {

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
@@ -154,7 +154,21 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
 
         if (entity is IEnumerable<object> sequence)
         {
-            _seedData.AddRange(sequence);
+            // Walk the sequence so a List<string> (or any IEnumerable that wraps strings)
+            // is rejected element-by-element, matching the per-item check the params
+            // overload performs in its foreach. Without this, the runtime
+            // IEnumerable<object> cast (which works because IEnumerable<T> is covariant
+            // in T for reference types) would let a List<string> through as silent
+            // seed data.
+            foreach (var item in sequence)
+            {
+                if (item is string)
+                {
+                    throw new ArgumentException("One of the entities passed in is of type string", nameof(entity));
+                }
+
+                _seedData.Add(item);
+            }
         }
         else
         {

--- a/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilder.cs
@@ -141,9 +141,11 @@ public class DbContextBuilder<T> where T : DbContext
 
         if (entity is IEnumerable<object> sequence)
         {
-            // Reject string elements per-item, matching the foreach in the params overload.
-            // IEnumerable<T> is covariant in T for reference types, so List<string> casts
-            // to IEnumerable<object> at runtime and would slip through without this check.
+            // Buffer first so the failing call leaves `_seedData` untouched (atomic w.r.t.
+            // seed state). IEnumerable<T> is covariant in T for reference types, so
+            // List<string> casts to IEnumerable<object> at runtime and would slip through
+            // without the per-item check below.
+            var buffer = new List<object>();
             foreach (var item in sequence)
             {
                 if (item is string)
@@ -151,8 +153,10 @@ public class DbContextBuilder<T> where T : DbContext
                     throw new ArgumentException("One of the entities passed in is of type string", nameof(entity));
                 }
 
-                _seedData.Add(item);
+                buffer.Add(item);
             }
+
+            _seedData.AddRange(buffer);
         }
         else
         {

--- a/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilder.cs
@@ -141,7 +141,18 @@ public class DbContextBuilder<T> where T : DbContext
 
         if (entity is IEnumerable<object> sequence)
         {
-            _seedData.AddRange(sequence);
+            // Reject string elements per-item, matching the foreach in the params overload.
+            // IEnumerable<T> is covariant in T for reference types, so List<string> casts
+            // to IEnumerable<object> at runtime and would slip through without this check.
+            foreach (var item in sequence)
+            {
+                if (item is string)
+                {
+                    throw new ArgumentException("One of the entities passed in is of type string", nameof(entity));
+                }
+
+                _seedData.Add(item);
+            }
         }
         else
         {

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbContextBuilderTestsBase.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbContextBuilderTestsBase.cs
@@ -1259,17 +1259,17 @@ public abstract class DbContextBuilderTestsBase
 
 
 
-    /// <summary>
-    /// Regression: when the caller widens TEntity to <see cref="object"/> the static
-    /// `typeof(TEntity) == typeof(string)` check (the original guard) would pass through
-    /// and silently seed the string. The current guard uses a runtime `entity is string`
-    /// check and must still reject.
+    /// Regression: the singleton overload accepts a single TEntity, but
+    /// `List&lt;string&gt;` casts to `IEnumerable&lt;object&gt;` at runtime (T-covariance for
+    /// reference types) — so without an element-level check, a list of strings would
+    /// slip through as seed data. This test pins the fix.
     /// </summary>
     [Fact]
-    public void SeedWith_singleton_overload_when_TEntity_is_widened_to_object_still_rejects_string()
+    public void SeedWith_singleton_overload_when_passed_a_List_of_strings_throws()
     {
         using var sut = CreateDbContextBuilder();
+        var stringList = new List<string> { "a", "b", "c" };
 
-        Assert.Throws<ArgumentException>(() => sut.SeedWith<object>("not an entity"));
+        Assert.Throws<ArgumentException>(() => sut.SeedWith(stringList));
     }
 }

--- a/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/DbContextBuilderTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/DbContextBuilderTests.cs
@@ -871,4 +871,37 @@ public class DbContextBuilderTests
         Assert.Single(context.Products);
         Assert.Single(context.Categories);
     }
+
+
+
+    /// <summary>
+    /// Regression: the singleton overload accepts a single TEntity, but
+    /// <c>List&lt;string&gt;</c> casts to <c>IEnumerable&lt;object&gt;</c> at runtime
+    /// (T-covariance for reference types) — so without an element-level check, a list
+    /// of strings would slip through as silent seed data. Mirrors the Core builder's
+    /// regression test.
+    /// </summary>
+    [Fact]
+    public void SeedWith_singleton_overload_when_passed_a_List_of_strings_throws()
+    {
+        var sut = new DbContextBuilder<TestDbContext>();
+        var stringList = new List<string> { "a", "b", "c" };
+
+        Assert.Throws<ArgumentException>(() => sut.SeedWith(stringList));
+    }
+
+
+
+    /// <summary>
+    /// Regression: when the caller widens TEntity to <see cref="object"/> the
+    /// static `typeof(TEntity) == typeof(string)` check (the original guard) would
+    /// pass through. The runtime <c>entity is string</c> check must still reject.
+    /// </summary>
+    [Fact]
+    public void SeedWith_singleton_overload_when_TEntity_is_widened_to_object_still_rejects_string()
+    {
+        var sut = new DbContextBuilder<TestDbContext>();
+
+        Assert.Throws<ArgumentException>(() => sut.SeedWith<object>("not an entity"));
+    }
 }


### PR DESCRIPTION
## Summary

Stacked on #270. The singleton `SeedWith<TEntity>(TEntity entity)` overload added in #270 accepts any `TEntity`, then runtime-checks `entity is IEnumerable<object>` and `AddRange`s. Because `IEnumerable<T>` is covariant in `T` for reference types, `List<string>` casts to `IEnumerable<object>` — so without an element-level check, callers passing a `List<string>` would silently seed strings as entities.

Walk the sequence and reject string elements per-item, matching the foreach + `case string` arm of the params overload. Same fix applied to classic-EF6.

Regression test `SeedWith_singleton_overload_when_passed_a_List_of_strings_throws` pins the behavior.

## Test plan

- [x] 226 tests pass on net10.0
- [ ] CI