### PR TITLE
test: cover DbContextActivator both factory paths (follow-up to #271)

### DIFF
--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbContextActivatorTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbContextActivatorTests.cs
@@ -24,7 +24,7 @@ public class DbContextActivatorTests
             .UseInMemoryDatabase($"happy-{Guid.NewGuid()}")
             .Options;
 
-        var context = DbContextActivator<ContextWithGenericOptionsCtor>.Create(options);
+        using var context = DbContextActivator<ContextWithGenericOptionsCtor>.Create(options);
 
         Assert.NotNull(context);
         Assert.IsType<ContextWithGenericOptionsCtor>(context);
@@ -46,7 +46,7 @@ public class DbContextActivatorTests
             .UseInMemoryDatabase($"fallback-{Guid.NewGuid()}")
             .Options;
 
-        var context = DbContextActivator<ContextWithNonGenericOptionsCtor>.Create(options);
+        using var context = DbContextActivator<ContextWithNonGenericOptionsCtor>.Create(options);
 
         Assert.NotNull(context);
         Assert.IsType<ContextWithNonGenericOptionsCtor>(context);

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbContextActivatorTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbContextActivatorTests.cs
@@ -1,0 +1,76 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolfgang.DbContextBuilderCore.Tests.Unit;
+
+/// <summary>
+/// Tests for <see cref="DbContextActivator{TDbContext}"/> — specifically the two paths
+/// inside <c>BuildFactory</c>: the compiled-delegate happy path (covered indirectly by
+/// every test that uses <c>UseInMemory()</c> or <c>UseSqlite()</c>), and the fallback to
+/// <c>Activator.CreateInstance</c> when the target type does not expose a
+/// <see cref="DbContextOptions{TContext}"/> ctor.
+/// </summary>
+public class DbContextActivatorTests
+{
+
+    /// <summary>
+    /// The happy path: a DbContext with a <c>DbContextOptions&lt;TContext&gt;</c> ctor
+    /// goes through the compiled Expression delegate and is instantiated.
+    /// </summary>
+    [Fact]
+    public void Create_when_TDbContext_has_a_generic_options_ctor_returns_a_new_instance()
+    {
+        var options = new DbContextOptionsBuilder<ContextWithGenericOptionsCtor>()
+            .UseInMemoryDatabase($"happy-{Guid.NewGuid()}")
+            .Options;
+
+        var context = DbContextActivator<ContextWithGenericOptionsCtor>.Create(options);
+
+        Assert.NotNull(context);
+        Assert.IsType<ContextWithGenericOptionsCtor>(context);
+    }
+
+
+
+    /// <summary>
+    /// Fallback path: a DbContext whose only ctor takes the non-generic
+    /// <see cref="DbContextOptions"/> (not <see cref="DbContextOptions{TContext}"/>)
+    /// makes <c>GetConstructor</c> return <c>null</c>, so <c>BuildFactory</c> falls back
+    /// to <see cref="Activator.CreateInstance(Type, object[])"/>. That fallback must
+    /// still successfully construct the type.
+    /// </summary>
+    [Fact]
+    public void Create_when_TDbContext_only_has_a_non_generic_options_ctor_falls_back_to_Activator()
+    {
+        var options = new DbContextOptionsBuilder<ContextWithNonGenericOptionsCtor>()
+            .UseInMemoryDatabase($"fallback-{Guid.NewGuid()}")
+            .Options;
+
+        var context = DbContextActivator<ContextWithNonGenericOptionsCtor>.Create(options);
+
+        Assert.NotNull(context);
+        Assert.IsType<ContextWithNonGenericOptionsCtor>(context);
+    }
+
+
+
+    [ExcludeFromCodeCoverage(Justification = "Test-only DbContext used solely to exercise the activator's compiled-delegate path.")]
+    private sealed class ContextWithGenericOptionsCtor : DbContext
+    {
+        public ContextWithGenericOptionsCtor(DbContextOptions<ContextWithGenericOptionsCtor> options)
+            : base(options)
+        {
+        }
+    }
+
+
+
+    [ExcludeFromCodeCoverage(Justification = "Test-only DbContext used solely to exercise the activator's Activator.CreateInstance fallback path.")]
+    private sealed class ContextWithNonGenericOptionsCtor : DbContext
+    {
+        public ContextWithNonGenericOptionsCtor(DbContextOptions options)
+            : base(options)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on #271. `DbContextActivator<TDbContext>.BuildFactory` has two branches — compiled-Expression delegate (when `GetConstructor` finds a `(DbContextOptions<TContext>)` ctor) and `Activator.CreateInstance` fallback (when it doesn't). The 214 existing tests only exercise branch (1) because `AdventureWorksDbContext` has the generic ctor shape.

Adds two focused tests with nested test-only `DbContext` subclasses — one matching each ctor shape — so both paths are covered.

## Test plan

- [x] 2/2 new tests pass
- [ ] CI