### PR TITLE
fix: EF6 Build/BuildAsync no longer leaks the seed-time DbContext (more-review item 1)

### DIFF
--- a/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-EF6/DbContextBuilder.cs
@@ -212,16 +212,23 @@ public class DbContextBuilder<T> where T : DbContext
         var contextCreator = CreateDbContext ?? new EffortDbContextCreator();
         CreateDbContext = contextCreator;
 
-        var context = contextCreator.CreateDbContext<T>();
-        InitializeDatabase(context);
-
-        if (_seedData.Count > 0)
+        // Create a temporary context to initialize the database (via Effort's shared
+        // connection) and persist seed data. Dispose it before returning the caller's
+        // context — otherwise it leaks for the lifetime of the builder. The seed data
+        // remains because EffortDbContextCreator holds the underlying connection open
+        // independent of any one context.
+        using (var seedContext = contextCreator.CreateDbContext<T>())
         {
-            foreach (var entity in _seedData)
+            InitializeDatabase(seedContext);
+
+            if (_seedData.Count > 0)
             {
-                context.Set(entity.GetType()).Add(entity);
+                foreach (var entity in _seedData)
+                {
+                    seedContext.Set(entity.GetType()).Add(entity);
+                }
+                seedContext.SaveChanges();
             }
-            context.SaveChanges();
         }
 
         return contextCreator.CreateDbContext<T>();
@@ -239,16 +246,21 @@ public class DbContextBuilder<T> where T : DbContext
         var contextCreator = CreateDbContext ?? new EffortDbContextCreator();
         CreateDbContext = contextCreator;
 
-        var context = contextCreator.CreateDbContext<T>();
-        InitializeDatabase(context);
-
-        if (_seedData.Count > 0)
+        // Create a temporary context to initialize the database (via Effort's shared
+        // connection) and persist seed data. Dispose it before returning the caller's
+        // context — otherwise it leaks for the lifetime of the builder.
+        using (var seedContext = contextCreator.CreateDbContext<T>())
         {
-            foreach (var entity in _seedData)
+            InitializeDatabase(seedContext);
+
+            if (_seedData.Count > 0)
             {
-                context.Set(entity.GetType()).Add(entity);
+                foreach (var entity in _seedData)
+                {
+                    seedContext.Set(entity.GetType()).Add(entity);
+                }
+                await seedContext.SaveChangesAsync().ConfigureAwait(false);
             }
-            await context.SaveChangesAsync().ConfigureAwait(false);
         }
 
         return contextCreator.CreateDbContext<T>();


### PR DESCRIPTION
## Summary

EF6 `DbContextBuilder<T>.Build()` and `.BuildAsync()` created a temporary `DbContext` to seed via `SaveChanges`, then returned a *second* `CreateDbContext<T>()` instance — never disposing the first. Every call leaked one `DbContext` for the lifetime of the builder.

The seed data still persists across contexts because `EffortDbContextCreator` holds the underlying in-memory connection open independent of any one context, so the second-context return semantics are intact. Disposing the seed context is what should always have happened.

Wrap the seed context in `using`. Core's `BuildAsync` already does this correctly via `await using` — not a Core regression.

## Test plan

- [x] `dotnet build -c Release` — clean on EF6 src
- [x] 70 EF6 tests pass on net462 + net472
- [ ] CI