### PR TITLE
docs: XML contract clarifications (more-review items 3, 7, 8, 10)

### DIFF
--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
@@ -37,6 +37,11 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// Instructs the builder to use InMemory as the database provider.
     /// </summary>
     /// <returns><see cref="DbContextBuilder{T}"/></returns>
+    /// <remarks>
+    /// Provider selection is last-write-wins — calling <see cref="UseInMemory"/> after a
+    /// previous call to either <see cref="UseInMemory"/> or a SQLite extension overrides
+    /// the earlier choice. Choose one provider per builder.
+    /// </remarks>
     public DbContextBuilder<T> UseInMemory()
     {
         CreateDbContext = new InMemoryDbContextCreator();
@@ -85,6 +90,15 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// <exception cref="ArgumentNullException">entities is null</exception>
     /// <exception cref="ArgumentException">entities contains a null item</exception>
     /// <exception cref="ArgumentException">entities contains a string</exception>
+    /// <remarks>
+    /// Insertion order across distinct entity types is not guaranteed — the builder
+    /// accumulates seeds in a single list and EF's <c>SaveChangesAsync</c> orders the
+    /// inserts by FK dependency, not by the order <c>SeedWith</c> calls were made. For
+    /// scenarios where the order of two same-type rows matters (e.g. identity-generated
+    /// keys), pass them in the desired order within a single <c>SeedWith</c> call.
+    /// Inheritance mapping (TPH / TPT / TPC) is supported via <c>entity.GetType()</c>;
+    /// the runtime type determines which DbSet receives the row.
+    /// </remarks>
     public DbContextBuilder<T> SeedWith<TEntity>(IEnumerable<TEntity> entities)
         where TEntity : class
     {

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderSqliteExtensions.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderSqliteExtensions.cs
@@ -17,6 +17,12 @@ public static class DbContextBuilderSqliteExtensions
     /// Instructs the builder to use SQLite as the database provider.
     /// </summary>
     /// <returns><see cref="DbContextBuilder{T}"/></returns>
+    /// <remarks>
+    /// Provider selection is last-write-wins — calling <c>UseSqlite</c> after a previous
+    /// <c>UseInMemory</c>, <c>UseSqlite</c>, or <c>UseSqliteForMsSqlServer</c> call
+    /// overrides the earlier choice.
+    /// Choose one provider per builder.
+    /// </remarks>
     public static DbContextBuilder<TDbContext> UseSqlite<TDbContext>
     (
         this DbContextBuilder<TDbContext> builder

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderSqliteExtensions.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderSqliteExtensions.cs
@@ -40,6 +40,11 @@ public static class DbContextBuilderSqliteExtensions
     /// such as default value mappings, to better mimic SQL Server behavior for testing or compatibility.
     /// </summary>
     /// <returns><see cref="DbContextBuilder{T}"/></returns>
+    /// <remarks>
+    /// Provider selection is last-write-wins — calling <c>UseSqliteForMsSqlServer</c> after a
+    /// previous <c>UseInMemory</c>, <c>UseSqlite</c>, or <c>UseSqliteForMsSqlServer</c> call
+    /// overrides the earlier choice.
+    /// </remarks>
     public static DbContextBuilder<TDbContext> UseSqliteForMsSqlServer<TDbContext>
     (
         this DbContextBuilder<TDbContext> builder

--- a/src/Wolfgang.DbContextBuilder-Core/SqliteModelCustomizer.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/SqliteModelCustomizer.cs
@@ -88,6 +88,11 @@ public class SqliteModelCustomizer : ModelCustomizer
     /// <c>lower(hex(randomblob(16)))</c> respectively. Key lookups are case-insensitive
     /// (<see cref="StringComparer.OrdinalIgnoreCase"/>) so variant spellings produced by
     /// different EF versions match the same replacement entry.
+    ///
+    /// Configure this map during builder setup (before <c>BuildAsync</c>); mutating it
+    /// after the first <c>Customize</c> pass is unsupported because the customizer is
+    /// typically registered as a DI singleton and concurrent reads on the dictionary
+    /// during model build are not guarded.
     /// </remarks>
     public IDictionary<string, string> DefaultValueMap { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
## Summary

Document four contracts the existing XML docs leave implicit:

- **`UseInMemory`/`UseSqlite`/`UseSqliteForMsSqlServer`** are last-write-wins. Mentioned in their `<remarks>`.
- **`SeedWith` insertion order is not preserved across distinct entity types** — EF orders inserts by FK dependency. For same-type ordering, pass entities together in one `SeedWith` call.
- **Inheritance mapping (TPH/TPT/TPC)** is supported via `entity.GetType()` runtime lookup. Documented on `SeedWith`.
- **`DefaultValueMap` should be configured before the first `BuildAsync`** — the customizer is typically a DI singleton, so mutating after the first `Customize` pass races with concurrent reads.

Docs-only; no behavior change.

## Test plan

- [x] `dotnet build -c Release` — clean
- [ ] CI