### PR TITLE
docs: explain SqliteForMsSqlServer null-on-miss semantics (more-review item 13)

### DIFF
--- a/src/Wolfgang.DbContextBuilder-Core/SqliteForMsSqlServerModelCustomizer.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/SqliteForMsSqlServerModelCustomizer.cs
@@ -25,7 +25,15 @@ public class SqliteForMsSqlServerModelCustomizer : SqliteModelCustomizer
         DefaultValueMap.Add("(newid())", "lower(hex(randomblob(16)))");
         DefaultValueMap.Add("(getdate())", "datetime('now')");
 
-
+        // OverrideDefaultValueHandling returns null on a dictionary miss — intentional and
+        // a deliberate divergence from the base SqliteModelCustomizer (which returns the
+        // original defaultValue on miss). Rationale: an un-mapped SQL Server SQL function
+        // (e.g. NEWSEQUENTIALID(), SYSUTCDATETIME(), or a user-defined function) would
+        // succeed at model compile time on SQLite but fail at runtime when EF emits the
+        // default-value SQL into the CREATE TABLE statement. Returning null drops the
+        // default, letting SQLite use its column-type default — safer than passing through
+        // a function SQLite doesn't recognize. Callers who need a specific mapping should
+        // add it to DefaultValueMap.
         OverrideDefaultValueHandling = s =>
         {
             if (s == null)
@@ -38,8 +46,11 @@ public class SqliteForMsSqlServerModelCustomizer : SqliteModelCustomizer
                 : null;
         };
 
+        // OverrideComputedValueHandling strips ALL computed values. SQLite supports
+        // computed columns but only with a constrained SQL grammar; SQL-Server computed
+        // expressions almost always reference functions SQLite doesn't have. Dropping
+        // them is safer than passing them through — the column becomes a normal column,
+        // and tests can seed an explicit value if they need one.
         OverrideComputedValueHandling = _ => null;
-
-        
     }
 }


### PR DESCRIPTION
## Summary

The sub-agent flagged `SqliteForMsSqlServer.OverrideDefaultValueHandling` returning `null` on dictionary miss as either intentional (needs a comment) or a real divergence from the base `SqliteModelCustomizer` (which returns the original `defaultValue` on miss).

Investigation: it's intentional. An un-mapped SQL-Server SQL function (e.g. `NEWSEQUENTIALID`, `SYSUTCDATETIME`, any UDF) compiled into the EF model would succeed at startup on SQLite but fail at runtime when EF emits the default-value SQL into `CREATE TABLE`. Returning `null` drops the default so SQLite uses its column-type default — safer than passing through a function SQLite cannot resolve.

Same logic applies to `OverrideComputedValueHandling = _ => null` (strips ALL computed values): SQLite supports computed columns but only with a constrained SQL grammar that almost never matches SQL Server.

Document both decisions inline so the next reader doesn't have to reverse-engineer the rationale.

Pure docs; no behavior change.

## Test plan

- [x] Build clean
- [ ] CI