### PR TITLE
test: dispose DbContext in tests + fix empty-assert/naming (closes #329, #330)

### DIFF
--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbContextBuilderTestsBase.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DbContextBuilderTestsBase.cs
@@ -1266,6 +1266,7 @@ public abstract class DbContextBuilderTestsBase
 
 
 
+    /// <summary>
     /// Regression: the singleton overload accepts a single TEntity, but
     /// `List&lt;string&gt;` casts to `IEnumerable&lt;object&gt;` at runtime (T-covariance for
     /// reference types) — so without an element-level check, a list of strings would

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/IgnoreVirtualMembersCustomizationTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/IgnoreVirtualMembersCustomizationTests.cs
@@ -90,7 +90,7 @@ public class IgnoreVirtualMembersCustomizationTests
     /// Verifies IgnoreVirtualMembersCustomization ignores virtual properties
     /// </summary>
     [Fact]
-    public void IgnoreVirtualMembersCustomization_ShouldIgnoreVirtualProperties()
+    public void Customize_when_entity_has_virtual_properties_ignores_them()
     {
         // Arrange
         var fixture = new Fixture();
@@ -110,7 +110,7 @@ public class IgnoreVirtualMembersCustomizationTests
     /// Verifies IgnoreVirtualMembersCustomization ignores virtual methods
     /// </summary>
     [Fact]
-    public void IgnoreVirtualMembersCustomization_ShouldIgnoreVirtualMethods()
+    public void Customize_when_entity_has_virtual_methods_ignores_them()
     {
         // Arrange
         var fixture = new Fixture();

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/IgnoreVirtualMembersTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/IgnoreVirtualMembersTests.cs
@@ -13,8 +13,11 @@ public class IgnoreVirtualMembersTests
     [Fact]
     public void Can_create_instance_of_IgnoreVirtualMembers()
     {
-        // Act & Assert
+        // Act
         var sut = new AutoFixtureRandomEntityCreator.IgnoreVirtualMembers();
+
+        // Assert
+        Assert.NotNull(sut);
     }
 
 

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/TestsWithDefaults.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/TestsWithDefaults.cs
@@ -40,7 +40,7 @@ public class TestsWithDefaults : DbContextBuilderTestsBase
         // Arrange
         var sut = new DbContextBuilder<AdventureWorksDbContext>();
 
-        var context = await sut.BuildAsync();
+        await using var context = await sut.BuildAsync();
 
         // Act & Assert
         Assert.True(context.Database.IsInMemory());

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/TestsWithInMemoryDBAndAutoFixture.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/TestsWithInMemoryDBAndAutoFixture.cs
@@ -72,7 +72,7 @@ public class TestsWithInMemoryDbAndAutoFixture : DbContextBuilderTestsBase
     public async Task Database_is_InMemory()
     {
         // Arrange
-        var sut = await new DbContextBuilder<AdventureWorksDbContext>().BuildAsync();
+        await using var sut = await new DbContextBuilder<AdventureWorksDbContext>().BuildAsync();
 
         // Act & Assert
         Assert.True(sut.Database.IsInMemory());

--- a/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/DbContextBuilderTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/DbContextBuilderTests.cs
@@ -38,7 +38,7 @@ public class DbContextBuilderTests
         var sut = CreateDbContextBuilder();
 
         // Act
-        var context = sut.Build();
+        using var context = sut.Build();
 
         // Assert
         Assert.NotNull(context);
@@ -57,7 +57,7 @@ public class DbContextBuilderTests
         var sut = CreateDbContextBuilder();
 
         // Act
-        var context = await sut.BuildAsync();
+        using var context = await sut.BuildAsync();
 
         // Assert
         Assert.NotNull(context);
@@ -184,7 +184,7 @@ public class DbContextBuilderTests
         var sut = CreateDbContextBuilder();
 
         // Act
-        var context = sut.Build();
+        using var context = sut.Build();
 
         // Assert
         Assert.NotNull(context);
@@ -212,7 +212,7 @@ public class DbContextBuilderTests
         };
 
         // Act
-        var context = sut
+        using var context = sut
             .SeedWith(product)
             .Build();
 
@@ -319,7 +319,7 @@ public class DbContextBuilderTests
         };
 
         // Act
-        var context = sut
+        using var context = sut
             .SeedWith(new[] { expectedProduct }.AsEnumerable())
             .Build();
 
@@ -435,7 +435,7 @@ public class DbContextBuilderTests
         };
 
         // Act
-        var context = sut
+        using var context = sut
             .SeedWith(product1, product2)
             .Build();
 
@@ -496,7 +496,7 @@ public class DbContextBuilderTests
         // Arrange
         var sut = CreateDbContextBuilder();
 
-        var context = sut
+        using var context = sut
             .SeedWithRandom<Category>(count)
             .Build();
 
@@ -585,7 +585,7 @@ public class DbContextBuilderTests
             return p;
         });
 
-        var context = sut
+        using var context = sut
             .SeedWithRandom(count, func)
             .Build();
 
@@ -675,7 +675,7 @@ public class DbContextBuilderTests
             return p;
         });
 
-        var context = sut
+        using var context = sut
             .SeedWithRandom(count, func)
             .Build();
 
@@ -734,7 +734,7 @@ public class DbContextBuilderTests
             .UseAutoFixture();
 
         // Act
-        var context = sut.Build();
+        using var context = sut.Build();
 
         // Assert
         Assert.NotNull(context);
@@ -754,7 +754,7 @@ public class DbContextBuilderTests
             .UseAutoFixture();
 
         // Act
-        var context = await sut.BuildAsync();
+        using var context = await sut.BuildAsync();
 
         // Assert
         Assert.NotNull(context);
@@ -781,7 +781,7 @@ public class DbContextBuilderTests
         };
 
         // Act
-        var context = await sut
+        using var context = await sut
             .SeedWith(product)
             .BuildAsync();
 
@@ -828,7 +828,7 @@ public class DbContextBuilderTests
         var sut = CreateDbContextBuilder();
 
         // Act
-        var context = sut
+        using var context = sut
             .UseEffort()
             .UseEffort()
             .Build();
@@ -862,7 +862,7 @@ public class DbContextBuilderTests
         };
 
         // Act
-        var context = sut
+        using var context = sut
             .SeedWith(product)
             .SeedWith(category)
             .Build();


### PR DESCRIPTION
Closes #329, #330.

## #329 — dispose DbContext in unit tests
Wrapped undisposed `Build()` / `BuildAsync()` results so test contexts release their connection / in-memory database deterministically instead of leaking to GC:

- **EF6 unit tests** (`DbContextBuilderTests.cs`) — 14 sites. EF6 `DbContext` is `IDisposable` only (not `IAsyncDisposable`), so `using var` (sync dispose) is used even for `await BuildAsync()`.
- **Core** `TestsWithDefaults.cs` (1) + `TestsWithInMemoryDBAndAutoFixture.cs` (1) — `await using var` (EF Core `DbContext` is `IAsyncDisposable`).
- The **EF7–EF10** sibling test projects link these same Core files via `<Compile Include=… Link=…/>`, so they are covered by the same edit.
- The throwing-assertion site in `TestsWithDefaults.cs` (`Assert.ThrowsAsync(... BuildAsync())`) was intentionally left alone — `BuildAsync` throws there, so no context is created.

## #330 — IgnoreVirtualMembers test hygiene
- `Can_create_instance_of_IgnoreVirtualMembers` gains an explicit `Assert.NotNull(sut)` (was assert-less).
- `IgnoreVirtualMembersCustomization_ShouldIgnoreVirtualProperties` / `…ShouldIgnoreVirtualMethods` renamed to the `MethodUnderTest_when_condition_expected_result` convention.

## Incidental
- Fixed a pre-existing **CS1570** (missing `<summary>` open tag in `DbContextBuilderTestsBase.cs`) that blocked the Core test project from compiling under `GenerateDocumentationFile` + warnings-as-errors.

## Verification
- Core test project (net8.0): **119 passed**.
- EF6 test project (net48): 71 passed; 1 failure (`SeedWith_params_when_passed_an_array_of_strings_throws`) is **pre-existing on vNext** — unrelated to this PR — caused by the #274 singleton overload changing single-string overload resolution. Tracked separately as a vNext-health item.

> Note: CI will be red until the separate pre-existing vNext build breakages (NU1903 audit, S4136 method-adjacency, the EF6 paramName test) are addressed. None originate from this PR.
