### PR TITLE
fix: resolve vNext build-health blockers (NU1903 SQLite, S4136, EF6 paramName test)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Pinned `SQLitePCLRaw.lib.e_sqlite3` to `3.50.3` across the SQLite-enabled
+  packages, above the `<= 2.1.11` range affected by GHSA-2m69-gcr7-jv3q
+  (a vulnerability in the bundled SQLite native library). Consumers of the
+  SQLite providers now restore the patched native library.
+
 ## [0.6.2] - 2026-05-29
 
 Canonical maintenance round + binding-stability fix. No public API or

--- a/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
@@ -58,6 +58,8 @@
 	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[10.0.5,11.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[10.0.5,11.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[10.0.5,11.0.0)" />
+	  <!-- Pin SQLite native lib above SQLitePCLRaw.lib.e_sqlite3 2.1.2 (GHSA-2m69-gcr7-jv3q / NU1903). -->
+	  <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
 	</ItemGroup>
 	<ItemGroup>
 		<!-- Include the icon and README file directly in the package's root -->

--- a/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
@@ -58,6 +58,8 @@
 	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6.0.36,7.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[6.0.36,7.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[6.0.36,7.0.0)" />
+	  <!-- Pin SQLite native lib above SQLitePCLRaw.lib.e_sqlite3 2.1.2 (GHSA-2m69-gcr7-jv3q / NU1903). -->
+	  <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
 	</ItemGroup>
 	<ItemGroup>
 		<!-- Include the icon and README file directly in the package's root -->

--- a/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
@@ -58,6 +58,8 @@
 	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[7.0.20,8.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[7.0.20,8.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[7.0.20,8.0.0)" />
+	  <!-- Pin SQLite native lib above SQLitePCLRaw.lib.e_sqlite3 2.1.2 (GHSA-2m69-gcr7-jv3q / NU1903). -->
+	  <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
 	</ItemGroup>
 	<ItemGroup>
 		<!-- Include the icon and README file directly in the package's root -->

--- a/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
@@ -58,6 +58,8 @@
 	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[8.0.25,9.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[8.0.25,9.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[8.0.25,9.0.0)" />
+	  <!-- Pin SQLite native lib above SQLitePCLRaw.lib.e_sqlite3 2.1.2 (GHSA-2m69-gcr7-jv3q / NU1903). -->
+	  <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
 	</ItemGroup>
 	<ItemGroup>
 		<!-- Include the icon and README file directly in the package's root -->

--- a/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
@@ -58,6 +58,8 @@
 	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[9.0.14,10.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[9.0.14,10.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[9.0.14,10.0.0)" />
+	  <!-- Pin SQLite native lib above SQLitePCLRaw.lib.e_sqlite3 2.1.2 (GHSA-2m69-gcr7-jv3q / NU1903). -->
+	  <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
 	</ItemGroup>
 	<ItemGroup>
 		<!-- Include the icon and README file directly in the package's root -->

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
@@ -137,37 +137,6 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
 
 
     /// <summary>
-    /// Shared validation + add loop for both <see cref="SeedWith{TEntity}(IEnumerable{TEntity})"/>
-    /// and <see cref="SeedWith{TEntity}(TEntity[])"/>. Keeps the null/string/IEnumerable
-    /// arms in one place so the two overloads cannot drift. <paramref name="paramName"/>
-    /// is forwarded to <see cref="ArgumentException.ParamName"/> so the public overload's
-    /// argument name is preserved on failure.
-    /// </summary>
-    /// <exception cref="ArgumentException">An element of <paramref name="source"/> is null or a string.</exception>
-    private void AddSeedItems<TEntity>(IEnumerable<TEntity> source, string paramName)
-        where TEntity : class
-    {
-        foreach (var entity in source)
-        {
-            switch (entity)
-            {
-                case null:
-                    throw new ArgumentException("One of the entities is null", paramName);
-                case string:
-                    throw new ArgumentException("One of the entities passed in is of type string", paramName);
-                case IEnumerable<object> e:
-                    _seedData.AddRange(e);
-                    break;
-                default:
-                    _seedData.Add(entity);
-                    break;
-            }
-        }
-    }
-
-
-
-    /// <summary>
     /// Populates the specified DbSet with a single entity. Equivalent to calling the
     /// <c>params</c>-array overload with one element, but avoids the per-call allocation
     /// of a one-element array — useful in tests that seed many single rows.
@@ -214,6 +183,37 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
         }
 
         return this;
+    }
+
+
+
+    /// <summary>
+    /// Shared validation + add loop for both <see cref="SeedWith{TEntity}(IEnumerable{TEntity})"/>
+    /// and <see cref="SeedWith{TEntity}(TEntity[])"/>. Keeps the null/string/IEnumerable
+    /// arms in one place so the two overloads cannot drift. <paramref name="paramName"/>
+    /// is forwarded to <see cref="ArgumentException.ParamName"/> so the public overload's
+    /// argument name is preserved on failure.
+    /// </summary>
+    /// <exception cref="ArgumentException">An element of <paramref name="source"/> is null or a string.</exception>
+    private void AddSeedItems<TEntity>(IEnumerable<TEntity> source, string paramName)
+        where TEntity : class
+    {
+        foreach (var entity in source)
+        {
+            switch (entity)
+            {
+                case null:
+                    throw new ArgumentException("One of the entities is null", paramName);
+                case string:
+                    throw new ArgumentException("One of the entities passed in is of type string", paramName);
+                case IEnumerable<object> e:
+                    _seedData.AddRange(e);
+                    break;
+                default:
+                    _seedData.Add(entity);
+                    break;
+            }
+        }
     }
 
 

--- a/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj
@@ -39,6 +39,8 @@
 	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6.0.36,7.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[6.0.36,7.0.0)" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[6.0.36,7.0.0)" />
+	  <!-- Pin SQLite native lib above SQLitePCLRaw.lib.e_sqlite3 2.1.2 (GHSA-2m69-gcr7-jv3q / NU1903). -->
+	  <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
 	</ItemGroup>
 	<ItemGroup>
 		<!-- Include the icon and README file directly in the package's root -->

--- a/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/DbContextBuilderTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/DbContextBuilderTests.cs
@@ -402,8 +402,9 @@ public class DbContextBuilderTests
         // Arrange
         var sut = CreateDbContextBuilder();
 
-        // Act & Assert
-        var ex = Assert.Throws<ArgumentException>(() => sut.SeedWith("Invalid value"));
+        // Act & Assert — two string args bind unambiguously to the params overload
+        // (a single string arg now binds to the SeedWith(TEntity) singleton overload).
+        var ex = Assert.Throws<ArgumentException>(() => sut.SeedWith("Invalid value", "another value"));
         Assert.Equal("entities", ex.ParamName);
     }
 


### PR DESCRIPTION
Fixes the three pre-existing build-health blockers on `vNext` so the integration branch (and the stacked PRs feeding it) can go green.

## NU1903 — vulnerable SQLite native library
`Microsoft.EntityFrameworkCore.Sqlite` transitively pulled `SQLitePCLRaw.lib.e_sqlite3 2.1.2`, flagged by [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) (vulnerability in the bundled SQLite native lib). The advisory affects **`<= 2.1.11`**; the first patched release is **`3.50.3`** (new SQLite-aligned versioning). Pinned `SQLitePCLRaw.lib.e_sqlite3` to `3.50.3` in all six SQLite-referencing src csprojs. Verified the 3.50.x native lib works at runtime with the 2.1.x managed provider — all SQLite tests pass.

## S4136 — "SeedWith overloads should be adjacent"
The private `AddSeedItems` helper sat between the `SeedWith` overloads in `DbContextBuilder.cs` (Core), tripping the analyzer as an error. Moved it below the three `SeedWith` overloads — no behavior change. (The EF6-classic source already had its overloads adjacent.)

## EF6 paramName test
`SeedWith_params_when_passed_an_array_of_strings_throws` asserted `ParamName == "entities"`, but after #274 added the `SeedWith<TEntity>(TEntity entity)` singleton overload, a single-string argument binds to the singleton (`"entity"`). Changed the call to two string args so it unambiguously exercises the **params** overload.

## Verification
- Core test project (net8.0): **259 passed** with full audit/analyzer gates (no suppression).
- EF6 test project (net48): **72 passed**.
- All src projects (EF6–EF10 + default Core) build clean in Release with full gates.

CHANGELOG gets a Security note for the SQLite pin (it affects the shipped SQLite packages).
