### PR TITLE
test: exclude EF8/9/10 AdventureWorks scaffolds from coverage

### DIFF
--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Address.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Address.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Street address information for customers, employees, and vendors.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Address{
     /// <summary>
     /// Primary key for Address records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/AddressType.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/AddressType.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Types of addresses stored in the Address table. 
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record AddressType{
     /// <summary>
     /// Primary key for AddressType records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/AdventureWorksDbContext.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/AdventureWorksDbContext.cs
@@ -2,8 +2,11 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial class AdventureWorksDbContext : DbContext
 {
     public AdventureWorksDbContext(DbContextOptions<AdventureWorksDbContext> options)

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/AwbuildVersion.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/AwbuildVersion.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Current version number of the AdventureWorks 2016 sample database. 
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record AwbuildVersion{
     /// <summary>
     /// Primary key for AWBuildVersion records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/BillOfMaterial.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/BillOfMaterial.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Items required to make bicycles and bicycle subassemblies. It identifies the heirarchical relationship between a parent product and its components.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record BillOfMaterial{
     /// <summary>
     /// Primary key for BillOfMaterials records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/BusinessEntity.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/BusinessEntity.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Source of the ID that connects vendors, customers, and employees with address and contact information.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record BusinessEntity{
     /// <summary>
     /// Primary key for all customers, vendors, and employees.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/BusinessEntityAddress.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/BusinessEntityAddress.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping customers, vendors, and employees to their addresses.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record BusinessEntityAddress{
     /// <summary>
     /// Primary key. Foreign key to BusinessEntity.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/BusinessEntityContact.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/BusinessEntityContact.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping stores, vendors, and employees to people
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record BusinessEntityContact{
     /// <summary>
     /// Primary key. Foreign key to BusinessEntity.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ContactType.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ContactType.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table containing the types of business entity contacts.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ContactType{
     /// <summary>
     /// Primary key for ContactType records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/CountryRegion.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/CountryRegion.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table containing the ISO standard codes for countries and regions.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record CountryRegion{
     /// <summary>
     /// ISO standard code for countries and regions.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/CountryRegionCurrency.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/CountryRegionCurrency.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping ISO currency codes to a country or region.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record CountryRegionCurrency{
     /// <summary>
     /// ISO code for countries and regions. Foreign key to CountryRegion.CountryRegionCode.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/CreditCard.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/CreditCard.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Customer credit card information.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record CreditCard{
     /// <summary>
     /// Primary key for CreditCard records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Culture.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Culture.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table containing the languages in which some AdventureWorks data is stored.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Culture{
     /// <summary>
     /// Primary key for Culture records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Currency.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Currency.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table containing standard ISO currencies.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Currency{
     /// <summary>
     /// The ISO code for the Currency.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/CurrencyRate.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/CurrencyRate.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Currency exchange rates.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record CurrencyRate{
     /// <summary>
     /// Primary key for CurrencyRate records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Customer.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Customer.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Current customer information. Also see the Person and Store tables.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Customer{
     /// <summary>
     /// Primary key.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/DatabaseLog.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/DatabaseLog.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Audit table tracking all DDL changes made to the AdventureWorks database. Data is captured by the database trigger ddlDatabaseTriggerLog.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record DatabaseLog{
     /// <summary>
     /// Primary key for DatabaseLog records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Department.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Department.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table containing the departments within the Adventure Works Cycles company.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Department{
     /// <summary>
     /// Primary key for Department records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/EmailAddress.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/EmailAddress.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Where to send a person email.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record EmailAddress{
     /// <summary>
     /// Primary key. Person associated with this email address.  Foreign key to Person.BusinessEntityID

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Employee.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Employee.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Employee information such as salary, department, and title.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Employee{
     /// <summary>
     /// Primary key for Employee records.  Foreign key to BusinessEntity.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/EmployeeDepartmentHistory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/EmployeeDepartmentHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Employee department transfers.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record EmployeeDepartmentHistory{
     /// <summary>
     /// Employee identification number. Foreign key to Employee.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/EmployeePayHistory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/EmployeePayHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Employee pay history.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record EmployeePayHistory{
     /// <summary>
     /// Employee identification number. Foreign key to Employee.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ErrorLog.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ErrorLog.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Audit table tracking errors in the the AdventureWorks database that are caught by the CATCH block of a TRY...CATCH construct. Data is inserted by stored procedure dbo.uspLogError when it is executed from inside the CATCH block of a TRY...CATCH construct.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ErrorLog{
     /// <summary>
     /// Primary key for ErrorLog records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Illustration.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Illustration.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Bicycle assembly diagrams.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Illustration{
     /// <summary>
     /// Primary key for Illustration records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/JobCandidate.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/JobCandidate.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Résumés submitted to Human Resources by job applicants.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record JobCandidate{
     /// <summary>
     /// Primary key for JobCandidate records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Location.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Location.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product inventory and manufacturing locations.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Location{
     /// <summary>
     /// Primary key for Location records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Password.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Password.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// One way hashed authentication information
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Password{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Person.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Person.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Human beings involved with AdventureWorks: employees, customer contacts, and vendor contacts.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Person{
     /// <summary>
     /// Primary key for Person records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/PersonCreditCard.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/PersonCreditCard.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping people to their credit card information in the CreditCard table. 
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record PersonCreditCard{
     /// <summary>
     /// Business entity identification number. Foreign key to Person.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/PersonPhone.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/PersonPhone.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Telephone number and type of a person.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record PersonPhone{
     /// <summary>
     /// Business entity identification number. Foreign key to Person.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/PhoneNumberType.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/PhoneNumberType.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Type of phone number of a person.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record PhoneNumberType{
     /// <summary>
     /// Primary key for telephone number type records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Product.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Product.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Products sold or used in the manfacturing of sold products.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Product{
     /// <summary>
     /// Primary key for Product records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductCategory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductCategory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// High-level product categorization.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductCategory{
     /// <summary>
     /// Primary key for ProductCategory records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductCostHistory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductCostHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Changes in the cost of a product over time.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductCostHistory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductDescription.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductDescription.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product descriptions in several languages.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductDescription{
     /// <summary>
     /// Primary key for ProductDescription records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductInventory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductInventory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product inventory information.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductInventory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductListPriceHistory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductListPriceHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Changes in the list price of a product over time.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductListPriceHistory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductModel.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductModel.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product model classification.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductModel{
     /// <summary>
     /// Primary key for ProductModel records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductModelIllustration.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductModelIllustration.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping product models and illustrations.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductModelIllustration{
     /// <summary>
     /// Primary key. Foreign key to ProductModel.ProductModelID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductModelProductDescriptionCulture.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductModelProductDescriptionCulture.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping product descriptions and the language the description is written in.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductModelProductDescriptionCulture{
     /// <summary>
     /// Primary key. Foreign key to ProductModel.ProductModelID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductPhoto.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductPhoto.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product images.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductPhoto{
     /// <summary>
     /// Primary key for ProductPhoto records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductProductPhoto.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductProductPhoto.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping products and product photos.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductProductPhoto{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductReview.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductReview.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Customer reviews of products they have purchased.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductReview{
     /// <summary>
     /// Primary key for ProductReview records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductSubcategory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductSubcategory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product subcategories. See ProductCategory table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductSubcategory{
     /// <summary>
     /// Primary key for ProductSubcategory records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ProductVendor.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ProductVendor.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping vendors with the products they supply.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductVendor{
     /// <summary>
     /// Primary key. Foreign key to Product.ProductID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/PurchaseOrderDetail.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/PurchaseOrderDetail.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Individual products associated with a specific purchase order. See PurchaseOrderHeader.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record PurchaseOrderDetail{
     /// <summary>
     /// Primary key. Foreign key to PurchaseOrderHeader.PurchaseOrderID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/PurchaseOrderHeader.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/PurchaseOrderHeader.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// General purchase order information. See PurchaseOrderDetail.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record PurchaseOrderHeader{
     /// <summary>
     /// Primary key.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesOrderDetail.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesOrderDetail.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Individual products associated with a specific sales order. See SalesOrderHeader.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesOrderDetail{
     /// <summary>
     /// Primary key. Foreign key to SalesOrderHeader.SalesOrderID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesOrderHeader.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesOrderHeader.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// General sales order information.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesOrderHeader{
     /// <summary>
     /// Primary key.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesOrderHeaderSalesReason.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesOrderHeaderSalesReason.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping sales orders to sales reason codes.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesOrderHeaderSalesReason{
     /// <summary>
     /// Primary key. Foreign key to SalesOrderHeader.SalesOrderID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesPerson.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesPerson.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Sales representative current information.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesPerson{
     /// <summary>
     /// Primary key for SalesPerson records. Foreign key to Employee.BusinessEntityID

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesPersonQuotaHistory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesPersonQuotaHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Sales performance tracking.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesPersonQuotaHistory{
     /// <summary>
     /// Sales person identification number. Foreign key to SalesPerson.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesReason.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesReason.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table of customer purchase reasons.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesReason{
     /// <summary>
     /// Primary key for SalesReason records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesTaxRate.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesTaxRate.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Tax rate lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesTaxRate{
     /// <summary>
     /// Primary key for SalesTaxRate records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesTerritory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesTerritory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Sales territory lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesTerritory{
     /// <summary>
     /// Primary key for SalesTerritory records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SalesTerritoryHistory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SalesTerritoryHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Sales representative transfers to other sales territories.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesTerritoryHistory{
     /// <summary>
     /// Primary key. The sales rep.  Foreign key to SalesPerson.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ScrapReason.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ScrapReason.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Manufacturing failure reasons lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ScrapReason{
     /// <summary>
     /// Primary key for ScrapReason records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Shift.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Shift.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Work shift lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Shift{
     /// <summary>
     /// Primary key for Shift records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ShipMethod.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ShipMethod.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Shipping company lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ShipMethod{
     /// <summary>
     /// Primary key for ShipMethod records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/ShoppingCartItem.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/ShoppingCartItem.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Contains online customer orders until the order is submitted or cancelled.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ShoppingCartItem{
     /// <summary>
     /// Primary key for ShoppingCartItem records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SpecialOffer.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SpecialOffer.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Sale discounts lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SpecialOffer{
     /// <summary>
     /// Primary key for SpecialOffer records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/SpecialOfferProduct.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/SpecialOfferProduct.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping products to special offer discounts.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SpecialOfferProduct{
     /// <summary>
     /// Primary key for SpecialOfferProduct records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/StateProvince.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/StateProvince.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// State and province lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record StateProvince{
     /// <summary>
     /// Primary key for StateProvince records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Store.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Store.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Customers (resellers) of Adventure Works products.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Store{
     /// <summary>
     /// Primary key. Foreign key to Customer.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/TransactionHistory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/TransactionHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Record of each purchase order, sales order, or work order transaction year to date.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record TransactionHistory{
     /// <summary>
     /// Primary key for TransactionHistory records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/TransactionHistoryArchive.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/TransactionHistoryArchive.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Transactions for previous years.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record TransactionHistoryArchive{
     /// <summary>
     /// Primary key for TransactionHistoryArchive records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/UnitMeasure.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/UnitMeasure.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Unit of measure lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record UnitMeasure{
     /// <summary>
     /// Primary key.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VAdditionalContactInfo.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VAdditionalContactInfo.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VAdditionalContactInfo{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VEmployee.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VEmployee.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VEmployee{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VEmployeeDepartment.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VEmployeeDepartment.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VEmployeeDepartment{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VEmployeeDepartmentHistory.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VEmployeeDepartmentHistory.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VEmployeeDepartmentHistory{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VIndividualCustomer.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VIndividualCustomer.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VIndividualCustomer{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VJobCandidate.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VJobCandidate.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VJobCandidate{
     public int JobCandidateId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VJobCandidateEducation.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VJobCandidateEducation.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VJobCandidateEducation{
     public int JobCandidateId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VJobCandidateEmployment.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VJobCandidateEmployment.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VJobCandidateEmployment{
     public int JobCandidateId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VPersonDemographic.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VPersonDemographic.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VPersonDemographic{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VProductAndDescription.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VProductAndDescription.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VProductAndDescription{
     public int ProductId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VProductModelCatalogDescription.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VProductModelCatalogDescription.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VProductModelCatalogDescription{
     public int ProductModelId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VProductModelInstruction.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VProductModelInstruction.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VProductModelInstruction{
     public int ProductModelId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VSalesPerson.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VSalesPerson.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VSalesPerson{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VSalesPersonSalesByFiscalYear.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VSalesPersonSalesByFiscalYear.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VSalesPersonSalesByFiscalYear{
     public int? SalesPersonId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VStateProvinceCountryRegion.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VStateProvinceCountryRegion.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VStateProvinceCountryRegion{
     public int StateProvinceId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VStoreWithAddress.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VStoreWithAddress.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VStoreWithAddress{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VStoreWithContact.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VStoreWithContact.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VStoreWithContact{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VStoreWithDemographic.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VStoreWithDemographic.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VStoreWithDemographic{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VVendorWithAddress.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VVendorWithAddress.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VVendorWithAddress{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/VVendorWithContact.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/VVendorWithContact.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VVendorWithContact{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/Vendor.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/Vendor.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Companies from whom Adventure Works Cycles purchases parts or other goods.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Vendor{
     /// <summary>
     /// Primary key for Vendor records.  Foreign key to BusinessEntity.BusinessEntityID

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/WorkOrder.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/WorkOrder.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Manufacturing work orders.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record WorkOrder{
     /// <summary>
     /// Primary key for WorkOrder records.

--- a/extra-projects/AdventureWorks-EF10/Models/Generated/WorkOrderRouting.cs
+++ b/extra-projects/AdventureWorks-EF10/Models/Generated/WorkOrderRouting.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Work order details.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record WorkOrderRouting{
     /// <summary>
     /// Primary key. Foreign key to WorkOrder.WorkOrderID.

--- a/extra-projects/AdventureWorks-EF10/Program.cs
+++ b/extra-projects/AdventureWorks-EF10/Program.cs
@@ -1,5 +1,6 @@
 namespace AdventureWorks_EF10
 {
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     internal class Program
     {
         static void Main(string[] args)

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Address.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Address.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Street address information for customers, employees, and vendors.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Address{
     /// <summary>
     /// Primary key for Address records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/AddressType.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/AddressType.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Types of addresses stored in the Address table. 
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record AddressType{
     /// <summary>
     /// Primary key for AddressType records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/AdventureWorksDbContext.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/AdventureWorksDbContext.cs
@@ -2,8 +2,11 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial class AdventureWorksDbContext : DbContext
 {
     public AdventureWorksDbContext(DbContextOptions<AdventureWorksDbContext> options)

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/AwbuildVersion.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/AwbuildVersion.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Current version number of the AdventureWorks 2016 sample database. 
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record AwbuildVersion{
     /// <summary>
     /// Primary key for AWBuildVersion records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/BillOfMaterial.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/BillOfMaterial.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Items required to make bicycles and bicycle subassemblies. It identifies the heirarchical relationship between a parent product and its components.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record BillOfMaterial{
     /// <summary>
     /// Primary key for BillOfMaterials records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/BusinessEntity.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/BusinessEntity.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Source of the ID that connects vendors, customers, and employees with address and contact information.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record BusinessEntity{
     /// <summary>
     /// Primary key for all customers, vendors, and employees.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/BusinessEntityAddress.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/BusinessEntityAddress.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping customers, vendors, and employees to their addresses.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record BusinessEntityAddress{
     /// <summary>
     /// Primary key. Foreign key to BusinessEntity.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/BusinessEntityContact.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/BusinessEntityContact.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping stores, vendors, and employees to people
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record BusinessEntityContact{
     /// <summary>
     /// Primary key. Foreign key to BusinessEntity.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ContactType.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ContactType.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table containing the types of business entity contacts.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ContactType{
     /// <summary>
     /// Primary key for ContactType records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/CountryRegion.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/CountryRegion.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table containing the ISO standard codes for countries and regions.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record CountryRegion{
     /// <summary>
     /// ISO standard code for countries and regions.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/CountryRegionCurrency.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/CountryRegionCurrency.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping ISO currency codes to a country or region.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record CountryRegionCurrency{
     /// <summary>
     /// ISO code for countries and regions. Foreign key to CountryRegion.CountryRegionCode.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/CreditCard.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/CreditCard.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Customer credit card information.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record CreditCard{
     /// <summary>
     /// Primary key for CreditCard records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Culture.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Culture.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table containing the languages in which some AdventureWorks data is stored.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Culture{
     /// <summary>
     /// Primary key for Culture records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Currency.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Currency.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table containing standard ISO currencies.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Currency{
     /// <summary>
     /// The ISO code for the Currency.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/CurrencyRate.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/CurrencyRate.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Currency exchange rates.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record CurrencyRate{
     /// <summary>
     /// Primary key for CurrencyRate records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Customer.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Customer.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Current customer information. Also see the Person and Store tables.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Customer{
     /// <summary>
     /// Primary key.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/DatabaseLog.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/DatabaseLog.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Audit table tracking all DDL changes made to the AdventureWorks database. Data is captured by the database trigger ddlDatabaseTriggerLog.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record DatabaseLog{
     /// <summary>
     /// Primary key for DatabaseLog records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Department.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Department.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table containing the departments within the Adventure Works Cycles company.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Department{
     /// <summary>
     /// Primary key for Department records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/EmailAddress.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/EmailAddress.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Where to send a person email.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record EmailAddress{
     /// <summary>
     /// Primary key. Person associated with this email address.  Foreign key to Person.BusinessEntityID

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Employee.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Employee.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Employee information such as salary, department, and title.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Employee{
     /// <summary>
     /// Primary key for Employee records.  Foreign key to BusinessEntity.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/EmployeeDepartmentHistory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/EmployeeDepartmentHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Employee department transfers.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record EmployeeDepartmentHistory{
     /// <summary>
     /// Employee identification number. Foreign key to Employee.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/EmployeePayHistory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/EmployeePayHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Employee pay history.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record EmployeePayHistory{
     /// <summary>
     /// Employee identification number. Foreign key to Employee.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ErrorLog.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ErrorLog.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Audit table tracking errors in the the AdventureWorks database that are caught by the CATCH block of a TRY...CATCH construct. Data is inserted by stored procedure dbo.uspLogError when it is executed from inside the CATCH block of a TRY...CATCH construct.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ErrorLog{
     /// <summary>
     /// Primary key for ErrorLog records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Illustration.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Illustration.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Bicycle assembly diagrams.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Illustration{
     /// <summary>
     /// Primary key for Illustration records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/JobCandidate.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/JobCandidate.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Résumés submitted to Human Resources by job applicants.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record JobCandidate{
     /// <summary>
     /// Primary key for JobCandidate records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Location.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Location.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product inventory and manufacturing locations.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Location{
     /// <summary>
     /// Primary key for Location records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Password.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Password.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// One way hashed authentication information
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Password{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Person.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Person.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Human beings involved with AdventureWorks: employees, customer contacts, and vendor contacts.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Person{
     /// <summary>
     /// Primary key for Person records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/PersonCreditCard.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/PersonCreditCard.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping people to their credit card information in the CreditCard table. 
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record PersonCreditCard{
     /// <summary>
     /// Business entity identification number. Foreign key to Person.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/PersonPhone.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/PersonPhone.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Telephone number and type of a person.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record PersonPhone{
     /// <summary>
     /// Business entity identification number. Foreign key to Person.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/PhoneNumberType.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/PhoneNumberType.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Type of phone number of a person.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record PhoneNumberType{
     /// <summary>
     /// Primary key for telephone number type records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Product.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Product.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Products sold or used in the manfacturing of sold products.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Product{
     /// <summary>
     /// Primary key for Product records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductCategory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductCategory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// High-level product categorization.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductCategory{
     /// <summary>
     /// Primary key for ProductCategory records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductCostHistory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductCostHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Changes in the cost of a product over time.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductCostHistory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductDescription.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductDescription.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product descriptions in several languages.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductDescription{
     /// <summary>
     /// Primary key for ProductDescription records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductInventory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductInventory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product inventory information.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductInventory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductListPriceHistory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductListPriceHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Changes in the list price of a product over time.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductListPriceHistory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductModel.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductModel.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product model classification.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductModel{
     /// <summary>
     /// Primary key for ProductModel records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductModelIllustration.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductModelIllustration.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping product models and illustrations.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductModelIllustration{
     /// <summary>
     /// Primary key. Foreign key to ProductModel.ProductModelID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductModelProductDescriptionCulture.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductModelProductDescriptionCulture.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping product descriptions and the language the description is written in.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductModelProductDescriptionCulture{
     /// <summary>
     /// Primary key. Foreign key to ProductModel.ProductModelID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductPhoto.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductPhoto.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product images.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductPhoto{
     /// <summary>
     /// Primary key for ProductPhoto records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductProductPhoto.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductProductPhoto.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping products and product photos.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductProductPhoto{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductReview.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductReview.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Customer reviews of products they have purchased.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductReview{
     /// <summary>
     /// Primary key for ProductReview records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductSubcategory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductSubcategory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product subcategories. See ProductCategory table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductSubcategory{
     /// <summary>
     /// Primary key for ProductSubcategory records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ProductVendor.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ProductVendor.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping vendors with the products they supply.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductVendor{
     /// <summary>
     /// Primary key. Foreign key to Product.ProductID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/PurchaseOrderDetail.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/PurchaseOrderDetail.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Individual products associated with a specific purchase order. See PurchaseOrderHeader.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record PurchaseOrderDetail{
     /// <summary>
     /// Primary key. Foreign key to PurchaseOrderHeader.PurchaseOrderID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/PurchaseOrderHeader.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/PurchaseOrderHeader.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// General purchase order information. See PurchaseOrderDetail.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record PurchaseOrderHeader{
     /// <summary>
     /// Primary key.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesOrderDetail.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesOrderDetail.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Individual products associated with a specific sales order. See SalesOrderHeader.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesOrderDetail{
     /// <summary>
     /// Primary key. Foreign key to SalesOrderHeader.SalesOrderID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesOrderHeader.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesOrderHeader.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// General sales order information.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesOrderHeader{
     /// <summary>
     /// Primary key.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesOrderHeaderSalesReason.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesOrderHeaderSalesReason.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping sales orders to sales reason codes.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesOrderHeaderSalesReason{
     /// <summary>
     /// Primary key. Foreign key to SalesOrderHeader.SalesOrderID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesPerson.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesPerson.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Sales representative current information.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesPerson{
     /// <summary>
     /// Primary key for SalesPerson records. Foreign key to Employee.BusinessEntityID

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesPersonQuotaHistory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesPersonQuotaHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Sales performance tracking.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesPersonQuotaHistory{
     /// <summary>
     /// Sales person identification number. Foreign key to SalesPerson.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesReason.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesReason.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table of customer purchase reasons.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesReason{
     /// <summary>
     /// Primary key for SalesReason records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesTaxRate.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesTaxRate.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Tax rate lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesTaxRate{
     /// <summary>
     /// Primary key for SalesTaxRate records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesTerritory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesTerritory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Sales territory lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesTerritory{
     /// <summary>
     /// Primary key for SalesTerritory records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SalesTerritoryHistory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SalesTerritoryHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Sales representative transfers to other sales territories.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesTerritoryHistory{
     /// <summary>
     /// Primary key. The sales rep.  Foreign key to SalesPerson.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ScrapReason.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ScrapReason.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Manufacturing failure reasons lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ScrapReason{
     /// <summary>
     /// Primary key for ScrapReason records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Shift.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Shift.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Work shift lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Shift{
     /// <summary>
     /// Primary key for Shift records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ShipMethod.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ShipMethod.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Shipping company lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ShipMethod{
     /// <summary>
     /// Primary key for ShipMethod records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/ShoppingCartItem.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/ShoppingCartItem.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Contains online customer orders until the order is submitted or cancelled.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ShoppingCartItem{
     /// <summary>
     /// Primary key for ShoppingCartItem records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SpecialOffer.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SpecialOffer.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Sale discounts lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SpecialOffer{
     /// <summary>
     /// Primary key for SpecialOffer records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/SpecialOfferProduct.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/SpecialOfferProduct.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping products to special offer discounts.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SpecialOfferProduct{
     /// <summary>
     /// Primary key for SpecialOfferProduct records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/StateProvince.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/StateProvince.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// State and province lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record StateProvince{
     /// <summary>
     /// Primary key for StateProvince records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Store.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Store.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Customers (resellers) of Adventure Works products.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Store{
     /// <summary>
     /// Primary key. Foreign key to Customer.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/TransactionHistory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/TransactionHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Record of each purchase order, sales order, or work order transaction year to date.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record TransactionHistory{
     /// <summary>
     /// Primary key for TransactionHistory records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/TransactionHistoryArchive.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/TransactionHistoryArchive.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Transactions for previous years.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record TransactionHistoryArchive{
     /// <summary>
     /// Primary key for TransactionHistoryArchive records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/UnitMeasure.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/UnitMeasure.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Unit of measure lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record UnitMeasure{
     /// <summary>
     /// Primary key.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VAdditionalContactInfo.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VAdditionalContactInfo.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VAdditionalContactInfo{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VEmployee.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VEmployee.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VEmployee{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VEmployeeDepartment.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VEmployeeDepartment.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VEmployeeDepartment{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VEmployeeDepartmentHistory.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VEmployeeDepartmentHistory.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VEmployeeDepartmentHistory{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VIndividualCustomer.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VIndividualCustomer.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VIndividualCustomer{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VJobCandidate.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VJobCandidate.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VJobCandidate{
     public int JobCandidateId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VJobCandidateEducation.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VJobCandidateEducation.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VJobCandidateEducation{
     public int JobCandidateId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VJobCandidateEmployment.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VJobCandidateEmployment.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VJobCandidateEmployment{
     public int JobCandidateId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VPersonDemographic.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VPersonDemographic.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VPersonDemographic{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VProductAndDescription.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VProductAndDescription.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VProductAndDescription{
     public int ProductId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VProductModelCatalogDescription.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VProductModelCatalogDescription.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VProductModelCatalogDescription{
     public int ProductModelId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VProductModelInstruction.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VProductModelInstruction.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VProductModelInstruction{
     public int ProductModelId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VSalesPerson.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VSalesPerson.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VSalesPerson{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VSalesPersonSalesByFiscalYear.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VSalesPersonSalesByFiscalYear.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VSalesPersonSalesByFiscalYear{
     public int? SalesPersonId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VStateProvinceCountryRegion.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VStateProvinceCountryRegion.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VStateProvinceCountryRegion{
     public int StateProvinceId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VStoreWithAddress.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VStoreWithAddress.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VStoreWithAddress{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VStoreWithContact.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VStoreWithContact.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VStoreWithContact{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VStoreWithDemographic.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VStoreWithDemographic.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VStoreWithDemographic{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VVendorWithAddress.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VVendorWithAddress.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VVendorWithAddress{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/VVendorWithContact.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/VVendorWithContact.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VVendorWithContact{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/Vendor.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/Vendor.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Companies from whom Adventure Works Cycles purchases parts or other goods.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Vendor{
     /// <summary>
     /// Primary key for Vendor records.  Foreign key to BusinessEntity.BusinessEntityID

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/WorkOrder.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/WorkOrder.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Manufacturing work orders.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record WorkOrder{
     /// <summary>
     /// Primary key for WorkOrder records.

--- a/extra-projects/AdventureWorks-EF8/Models/Generated/WorkOrderRouting.cs
+++ b/extra-projects/AdventureWorks-EF8/Models/Generated/WorkOrderRouting.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Work order details.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record WorkOrderRouting{
     /// <summary>
     /// Primary key. Foreign key to WorkOrder.WorkOrderID.

--- a/extra-projects/AdventureWorks-EF8/Program.cs
+++ b/extra-projects/AdventureWorks-EF8/Program.cs
@@ -1,5 +1,6 @@
 namespace AdventureWorks_EF8
 {
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     internal class Program
     {
         static void Main(string[] args)

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Address.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Address.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Street address information for customers, employees, and vendors.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Address{
     /// <summary>
     /// Primary key for Address records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/AddressType.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/AddressType.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Types of addresses stored in the Address table. 
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record AddressType{
     /// <summary>
     /// Primary key for AddressType records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/AdventureWorksDbContext.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/AdventureWorksDbContext.cs
@@ -2,8 +2,11 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial class AdventureWorksDbContext : DbContext
 {
     public AdventureWorksDbContext(DbContextOptions<AdventureWorksDbContext> options)

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/AwbuildVersion.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/AwbuildVersion.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Current version number of the AdventureWorks 2016 sample database. 
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record AwbuildVersion{
     /// <summary>
     /// Primary key for AWBuildVersion records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/BillOfMaterial.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/BillOfMaterial.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Items required to make bicycles and bicycle subassemblies. It identifies the heirarchical relationship between a parent product and its components.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record BillOfMaterial{
     /// <summary>
     /// Primary key for BillOfMaterials records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/BusinessEntity.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/BusinessEntity.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Source of the ID that connects vendors, customers, and employees with address and contact information.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record BusinessEntity{
     /// <summary>
     /// Primary key for all customers, vendors, and employees.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/BusinessEntityAddress.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/BusinessEntityAddress.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping customers, vendors, and employees to their addresses.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record BusinessEntityAddress{
     /// <summary>
     /// Primary key. Foreign key to BusinessEntity.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/BusinessEntityContact.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/BusinessEntityContact.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping stores, vendors, and employees to people
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record BusinessEntityContact{
     /// <summary>
     /// Primary key. Foreign key to BusinessEntity.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ContactType.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ContactType.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table containing the types of business entity contacts.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ContactType{
     /// <summary>
     /// Primary key for ContactType records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/CountryRegion.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/CountryRegion.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table containing the ISO standard codes for countries and regions.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record CountryRegion{
     /// <summary>
     /// ISO standard code for countries and regions.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/CountryRegionCurrency.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/CountryRegionCurrency.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping ISO currency codes to a country or region.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record CountryRegionCurrency{
     /// <summary>
     /// ISO code for countries and regions. Foreign key to CountryRegion.CountryRegionCode.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/CreditCard.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/CreditCard.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Customer credit card information.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record CreditCard{
     /// <summary>
     /// Primary key for CreditCard records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Culture.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Culture.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table containing the languages in which some AdventureWorks data is stored.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Culture{
     /// <summary>
     /// Primary key for Culture records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Currency.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Currency.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table containing standard ISO currencies.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Currency{
     /// <summary>
     /// The ISO code for the Currency.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/CurrencyRate.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/CurrencyRate.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Currency exchange rates.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record CurrencyRate{
     /// <summary>
     /// Primary key for CurrencyRate records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Customer.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Customer.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Current customer information. Also see the Person and Store tables.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Customer{
     /// <summary>
     /// Primary key.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/DatabaseLog.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/DatabaseLog.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Audit table tracking all DDL changes made to the AdventureWorks database. Data is captured by the database trigger ddlDatabaseTriggerLog.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record DatabaseLog{
     /// <summary>
     /// Primary key for DatabaseLog records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Department.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Department.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table containing the departments within the Adventure Works Cycles company.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Department{
     /// <summary>
     /// Primary key for Department records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/EmailAddress.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/EmailAddress.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Where to send a person email.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record EmailAddress{
     /// <summary>
     /// Primary key. Person associated with this email address.  Foreign key to Person.BusinessEntityID

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Employee.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Employee.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Employee information such as salary, department, and title.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Employee{
     /// <summary>
     /// Primary key for Employee records.  Foreign key to BusinessEntity.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/EmployeeDepartmentHistory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/EmployeeDepartmentHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Employee department transfers.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record EmployeeDepartmentHistory{
     /// <summary>
     /// Employee identification number. Foreign key to Employee.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/EmployeePayHistory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/EmployeePayHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Employee pay history.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record EmployeePayHistory{
     /// <summary>
     /// Employee identification number. Foreign key to Employee.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ErrorLog.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ErrorLog.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Audit table tracking errors in the the AdventureWorks database that are caught by the CATCH block of a TRY...CATCH construct. Data is inserted by stored procedure dbo.uspLogError when it is executed from inside the CATCH block of a TRY...CATCH construct.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ErrorLog{
     /// <summary>
     /// Primary key for ErrorLog records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Illustration.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Illustration.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Bicycle assembly diagrams.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Illustration{
     /// <summary>
     /// Primary key for Illustration records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/JobCandidate.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/JobCandidate.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Résumés submitted to Human Resources by job applicants.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record JobCandidate{
     /// <summary>
     /// Primary key for JobCandidate records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Location.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Location.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product inventory and manufacturing locations.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Location{
     /// <summary>
     /// Primary key for Location records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Password.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Password.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// One way hashed authentication information
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Password{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Person.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Person.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Human beings involved with AdventureWorks: employees, customer contacts, and vendor contacts.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Person{
     /// <summary>
     /// Primary key for Person records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/PersonCreditCard.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/PersonCreditCard.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping people to their credit card information in the CreditCard table. 
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record PersonCreditCard{
     /// <summary>
     /// Business entity identification number. Foreign key to Person.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/PersonPhone.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/PersonPhone.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Telephone number and type of a person.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record PersonPhone{
     /// <summary>
     /// Business entity identification number. Foreign key to Person.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/PhoneNumberType.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/PhoneNumberType.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Type of phone number of a person.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record PhoneNumberType{
     /// <summary>
     /// Primary key for telephone number type records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Product.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Product.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Products sold or used in the manfacturing of sold products.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Product{
     /// <summary>
     /// Primary key for Product records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductCategory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductCategory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// High-level product categorization.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductCategory{
     /// <summary>
     /// Primary key for ProductCategory records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductCostHistory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductCostHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Changes in the cost of a product over time.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductCostHistory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductDescription.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductDescription.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product descriptions in several languages.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductDescription{
     /// <summary>
     /// Primary key for ProductDescription records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductInventory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductInventory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product inventory information.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductInventory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductListPriceHistory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductListPriceHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Changes in the list price of a product over time.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductListPriceHistory{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductModel.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductModel.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product model classification.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductModel{
     /// <summary>
     /// Primary key for ProductModel records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductModelIllustration.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductModelIllustration.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping product models and illustrations.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductModelIllustration{
     /// <summary>
     /// Primary key. Foreign key to ProductModel.ProductModelID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductModelProductDescriptionCulture.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductModelProductDescriptionCulture.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping product descriptions and the language the description is written in.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductModelProductDescriptionCulture{
     /// <summary>
     /// Primary key. Foreign key to ProductModel.ProductModelID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductPhoto.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductPhoto.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product images.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductPhoto{
     /// <summary>
     /// Primary key for ProductPhoto records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductProductPhoto.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductProductPhoto.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping products and product photos.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductProductPhoto{
     /// <summary>
     /// Product identification number. Foreign key to Product.ProductID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductReview.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductReview.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Customer reviews of products they have purchased.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductReview{
     /// <summary>
     /// Primary key for ProductReview records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductSubcategory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductSubcategory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Product subcategories. See ProductCategory table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductSubcategory{
     /// <summary>
     /// Primary key for ProductSubcategory records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ProductVendor.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ProductVendor.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping vendors with the products they supply.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ProductVendor{
     /// <summary>
     /// Primary key. Foreign key to Product.ProductID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/PurchaseOrderDetail.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/PurchaseOrderDetail.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Individual products associated with a specific purchase order. See PurchaseOrderHeader.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record PurchaseOrderDetail{
     /// <summary>
     /// Primary key. Foreign key to PurchaseOrderHeader.PurchaseOrderID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/PurchaseOrderHeader.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/PurchaseOrderHeader.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// General purchase order information. See PurchaseOrderDetail.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record PurchaseOrderHeader{
     /// <summary>
     /// Primary key.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesOrderDetail.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesOrderDetail.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Individual products associated with a specific sales order. See SalesOrderHeader.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesOrderDetail{
     /// <summary>
     /// Primary key. Foreign key to SalesOrderHeader.SalesOrderID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesOrderHeader.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesOrderHeader.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// General sales order information.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesOrderHeader{
     /// <summary>
     /// Primary key.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesOrderHeaderSalesReason.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesOrderHeaderSalesReason.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping sales orders to sales reason codes.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesOrderHeaderSalesReason{
     /// <summary>
     /// Primary key. Foreign key to SalesOrderHeader.SalesOrderID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesPerson.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesPerson.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Sales representative current information.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesPerson{
     /// <summary>
     /// Primary key for SalesPerson records. Foreign key to Employee.BusinessEntityID

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesPersonQuotaHistory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesPersonQuotaHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Sales performance tracking.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesPersonQuotaHistory{
     /// <summary>
     /// Sales person identification number. Foreign key to SalesPerson.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesReason.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesReason.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Lookup table of customer purchase reasons.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesReason{
     /// <summary>
     /// Primary key for SalesReason records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesTaxRate.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesTaxRate.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Tax rate lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesTaxRate{
     /// <summary>
     /// Primary key for SalesTaxRate records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesTerritory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesTerritory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Sales territory lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesTerritory{
     /// <summary>
     /// Primary key for SalesTerritory records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SalesTerritoryHistory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SalesTerritoryHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Sales representative transfers to other sales territories.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SalesTerritoryHistory{
     /// <summary>
     /// Primary key. The sales rep.  Foreign key to SalesPerson.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ScrapReason.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ScrapReason.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Manufacturing failure reasons lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ScrapReason{
     /// <summary>
     /// Primary key for ScrapReason records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Shift.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Shift.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Work shift lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Shift{
     /// <summary>
     /// Primary key for Shift records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ShipMethod.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ShipMethod.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Shipping company lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ShipMethod{
     /// <summary>
     /// Primary key for ShipMethod records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/ShoppingCartItem.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/ShoppingCartItem.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Contains online customer orders until the order is submitted or cancelled.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record ShoppingCartItem{
     /// <summary>
     /// Primary key for ShoppingCartItem records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SpecialOffer.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SpecialOffer.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Sale discounts lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SpecialOffer{
     /// <summary>
     /// Primary key for SpecialOffer records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/SpecialOfferProduct.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/SpecialOfferProduct.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Cross-reference table mapping products to special offer discounts.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record SpecialOfferProduct{
     /// <summary>
     /// Primary key for SpecialOfferProduct records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/StateProvince.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/StateProvince.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// State and province lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record StateProvince{
     /// <summary>
     /// Primary key for StateProvince records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Store.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Store.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Customers (resellers) of Adventure Works products.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Store{
     /// <summary>
     /// Primary key. Foreign key to Customer.BusinessEntityID.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/TransactionHistory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/TransactionHistory.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Record of each purchase order, sales order, or work order transaction year to date.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record TransactionHistory{
     /// <summary>
     /// Primary key for TransactionHistory records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/TransactionHistoryArchive.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/TransactionHistoryArchive.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Transactions for previous years.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record TransactionHistoryArchive{
     /// <summary>
     /// Primary key for TransactionHistoryArchive records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/UnitMeasure.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/UnitMeasure.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Unit of measure lookup table.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record UnitMeasure{
     /// <summary>
     /// Primary key.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VAdditionalContactInfo.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VAdditionalContactInfo.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VAdditionalContactInfo{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VEmployee.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VEmployee.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VEmployee{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VEmployeeDepartment.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VEmployeeDepartment.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VEmployeeDepartment{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VEmployeeDepartmentHistory.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VEmployeeDepartmentHistory.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VEmployeeDepartmentHistory{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VIndividualCustomer.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VIndividualCustomer.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VIndividualCustomer{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VJobCandidate.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VJobCandidate.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VJobCandidate{
     public int JobCandidateId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VJobCandidateEducation.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VJobCandidateEducation.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VJobCandidateEducation{
     public int JobCandidateId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VJobCandidateEmployment.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VJobCandidateEmployment.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VJobCandidateEmployment{
     public int JobCandidateId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VPersonDemographic.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VPersonDemographic.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VPersonDemographic{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VProductAndDescription.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VProductAndDescription.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VProductAndDescription{
     public int ProductId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VProductModelCatalogDescription.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VProductModelCatalogDescription.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VProductModelCatalogDescription{
     public int ProductModelId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VProductModelInstruction.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VProductModelInstruction.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VProductModelInstruction{
     public int ProductModelId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VSalesPerson.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VSalesPerson.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VSalesPerson{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VSalesPersonSalesByFiscalYear.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VSalesPersonSalesByFiscalYear.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VSalesPersonSalesByFiscalYear{
     public int? SalesPersonId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VStateProvinceCountryRegion.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VStateProvinceCountryRegion.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VStateProvinceCountryRegion{
     public int StateProvinceId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VStoreWithAddress.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VStoreWithAddress.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VStoreWithAddress{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VStoreWithContact.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VStoreWithContact.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VStoreWithContact{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VStoreWithDemographic.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VStoreWithDemographic.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VStoreWithDemographic{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VVendorWithAddress.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VVendorWithAddress.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VVendorWithAddress{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/VVendorWithContact.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/VVendorWithContact.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record VVendorWithContact{
     public int BusinessEntityId { get; set; }
 

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/Vendor.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/Vendor.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Companies from whom Adventure Works Cycles purchases parts or other goods.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record Vendor{
     /// <summary>
     /// Primary key for Vendor records.  Foreign key to BusinessEntity.BusinessEntityID

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/WorkOrder.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/WorkOrder.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Manufacturing work orders.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record WorkOrder{
     /// <summary>
     /// Primary key for WorkOrder records.

--- a/extra-projects/AdventureWorks-EF9/Models/Generated/WorkOrderRouting.cs
+++ b/extra-projects/AdventureWorks-EF9/Models/Generated/WorkOrderRouting.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AdventureWorks.Models;
 
 /// <summary>
 /// Work order details.
 /// </summary>
+[ExcludeFromCodeCoverage(Justification = "This is a test model and not part of the production code")]
 public partial record WorkOrderRouting{
     /// <summary>
     /// Primary key. Foreign key to WorkOrder.WorkOrderID.

--- a/extra-projects/AdventureWorks-EF9/Program.cs
+++ b/extra-projects/AdventureWorks-EF9/Program.cs
@@ -1,5 +1,6 @@
 namespace AdventureWorks_EF9
 {
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     internal class Program
     {
         static void Main(string[] args)


### PR DESCRIPTION
Bottom of a 2-PR stack fixing the 0.7.0 coverage gate.

EF8/9/10 AdventureWorks scaffolds (added by #262) never received the `[ExcludeFromCodeCoverage]` attribute the EF6/EF7 generated models carry, so ~13.5k lines of near-0%-covered generated model code were counted by the gate — dragging coverage to 80.6% (< 90%).

Adds `[ExcludeFromCodeCoverage]` (+ using) to all 270 EF8/9/10 generated types and the `Program.cs` stubs, matching the EF6/EF7 convention.

Stacked: [test-link follow-up] builds on this. Recovers 80.6% → ~84.3% on its own; the follow-up takes it to ~99%.