### PR TITLE
test: exclude AdventureWorks-EF7 Program stub from coverage

### DIFF
--- a/extra-projects/AdventureWorks-EF7/Program.cs
+++ b/extra-projects/AdventureWorks-EF7/Program.cs
@@ -1,5 +1,6 @@
 namespace AdventureWorks_EF7
 {
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     internal class Program
     {
         static void Main(string[] args)


### PR DESCRIPTION
Final coverage-gate fix for 0.7.0.

The per-project coverage gate fails on `AdventureWorks-EF7 (0%)` / `AdventureWorks_EF7.Program (0%)` even though overall coverage is **98.9%** — EF7's `Program.cs` stub was the only AdventureWorks scaffold Program left without `[ExcludeFromCodeCoverage]` (EF6/8/9/10 already have it, added in #335).

Adds the attribute to `AdventureWorks-EF7/Program.cs`, matching the other EF versions. With this, no project sits below 90% and the gate passes.

Follows the #335/#336 coverage stack.