### PR TITLE
ci(release.yaml): isolate smoke-test projects from repo analyzer config

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -529,7 +529,8 @@ jobs:
               # single-TFM (EF6→net6.0 ... EF10→net10.0); a shared consumer would either fail
               # uplevel (net8.0 cannot restore a net10.0 package → NU1202) or unify the EF Core
               # versions across packages. One project per package avoids both.
-              $projName = 'Smoke_' + ($packageId -replace '[^A-Za-z0-9]', '_')
+              # No underscores in the assembly name (would trip CA1707 on net10.0).
+              $projName = 'Smoke' + ($packageId -replace '[^A-Za-z0-9]', '')
               Write-Host "🧪 Smoke testing package: $packageId $packageVersion ($coreTfm)" -ForegroundColor Yellow
 
               dotnet new console -n $projName -f $coreTfm
@@ -544,7 +545,10 @@ jobs:
                 exit $LASTEXITCODE
               }
 
-              dotnet build "$projName/$projName.csproj"
+              # Throwaway consumer: turn off the repo's inherited analyzers and
+              # Release warnings-as-errors (from Directory.Build.props). A real package
+              # consumer would not have them; the smoke test only verifies restore + compile.
+              dotnet build "$projName/$projName.csproj" -p:TreatWarningsAsErrors=false -p:RunAnalyzers=false -p:EnableNETAnalyzers=false
               if ($LASTEXITCODE -ne 0) {
                 Write-Error "❌ Smoke test project failed to build with $packageId"
                 exit $LASTEXITCODE


### PR DESCRIPTION
**Protected-only PR** — single file: `.github/workflows/release.yaml`. Second (and final) smoke-test fix for the 0.7.0 publish.

The previous fix (#338) made the smoke test TFM-aware — it now correctly installs/builds EF6–EF9 per-TFM and skips the Framework-only package. But it failed on **EF10** with:
```
error CA1707: Remove the underscores from assembly name Smoke_..._Core_EF10
```
The throwaway smoke projects are created under the repo root, so they inherit `Directory.Build.props` (analyzer packages + Release `TreatWarningsAsErrors`); `AnalysisLevel=latest` enables CA1707-as-error specifically on **net10.0** (older TFMs don't), which is why only EF10 tripped.

Fix: drop underscores from the smoke project name **and** build with `-p:RunAnalyzers=false -p:EnableNETAnalyzers=false -p:TreatWarningsAsErrors=false` — a real consumer wouldn't have the library's analyzer policy; the smoke test only needs to verify restore + compile.

`Detect .NET Projects` will fail (expected — protected file) → admin-bypass merge. After merge, I re-tag v0.7.0 at the new main HEAD and re-publish.