### PR TITLE
feat: reusable seed profiles (closes #104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New `ISeedProfile<T>` and `DbContextBuilder<T>.UseSeedProfile(ISeedProfile<T>)` —
+  reusable, named bundles of seed data that can be applied to any builder in one call.
+  Multiple profiles accumulate, so common setups can be shared across many test classes
+  instead of being re-built in each. (#104)
+
 ### Changed
 
 ### Fixed

--- a/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF10/Wolfgang.DbContextBuilder-Core-EF10.csproj
@@ -40,6 +40,7 @@
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assembly.cs" Link="Assembly.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\ICreateDbContext.cs" Link="ICreateDbContext.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\ICreateRandomEntities.cs" Link="ICreateRandomEntities.cs" />
+	   <Compile Include="../Wolfgang.DbContextBuilder-Core/ISeedProfile.cs" Link="ISeedProfile.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\InMemoryDbContextCreator.cs" Link="InMemoryDbContextCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteDbContextCreator.cs" Link="SqliteDbContextCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteForMsSqlServerModelCustomizer.cs" Link="SqliteForMsSqlServerModelCustomizer.cs" />

--- a/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF6/Wolfgang.DbContextBuilder-Core-EF6.csproj
@@ -40,6 +40,7 @@
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assembly.cs" Link="Assembly.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\ICreateDbContext.cs" Link="ICreateDbContext.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\ICreateRandomEntities.cs" Link="ICreateRandomEntities.cs" />
+	   <Compile Include="../Wolfgang.DbContextBuilder-Core/ISeedProfile.cs" Link="ISeedProfile.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\InMemoryDbContextCreator.cs" Link="InMemoryDbContextCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteDbContextCreator.cs" Link="SqliteDbContextCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteForMsSqlServerModelCustomizer.cs" Link="SqliteForMsSqlServerModelCustomizer.cs" />

--- a/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF7/Wolfgang.DbContextBuilder-Core-EF7.csproj
@@ -41,6 +41,7 @@
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assembly.cs" Link="Assembly.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\ICreateDbContext.cs" Link="ICreateDbContext.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\ICreateRandomEntities.cs" Link="ICreateRandomEntities.cs" />
+	   <Compile Include="../Wolfgang.DbContextBuilder-Core/ISeedProfile.cs" Link="ISeedProfile.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\InMemoryDbContextCreator.cs" Link="InMemoryDbContextCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteDbContextCreator.cs" Link="SqliteDbContextCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteForMsSqlServerModelCustomizer.cs" Link="SqliteForMsSqlServerModelCustomizer.cs" />

--- a/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj
@@ -40,6 +40,7 @@
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assembly.cs" Link="Assembly.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\ICreateDbContext.cs" Link="ICreateDbContext.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\ICreateRandomEntities.cs" Link="ICreateRandomEntities.cs" />
+	   <Compile Include="../Wolfgang.DbContextBuilder-Core/ISeedProfile.cs" Link="ISeedProfile.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\InMemoryDbContextCreator.cs" Link="InMemoryDbContextCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteDbContextCreator.cs" Link="SqliteDbContextCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteForMsSqlServerModelCustomizer.cs" Link="SqliteForMsSqlServerModelCustomizer.cs" />

--- a/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
+++ b/src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj
@@ -40,6 +40,7 @@
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\Assembly.cs" Link="Assembly.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\ICreateDbContext.cs" Link="ICreateDbContext.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\ICreateRandomEntities.cs" Link="ICreateRandomEntities.cs" />
+	   <Compile Include="../Wolfgang.DbContextBuilder-Core/ISeedProfile.cs" Link="ISeedProfile.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\InMemoryDbContextCreator.cs" Link="InMemoryDbContextCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteDbContextCreator.cs" Link="SqliteDbContextCreator.cs" />
 	   <Compile Include="..\Wolfgang.DbContextBuilder-Core\SqliteForMsSqlServerModelCustomizer.cs" Link="SqliteForMsSqlServerModelCustomizer.cs" />

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
@@ -83,6 +83,25 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
 
 
     /// <summary>
+    /// Applies a reusable <see cref="ISeedProfile{T}"/> to this builder. Profiles bundle
+    /// a complete set of seed data so the same setup can be shared across many tests with
+    /// a single call. Multiple profiles can be applied; their seed data accumulates.
+    /// </summary>
+    /// <param name="profile">The seed profile to apply.</param>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
+    /// <exception cref="ArgumentNullException"><paramref name="profile"/> is null.</exception>
+    public DbContextBuilder<T> UseSeedProfile(ISeedProfile<T> profile)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        profile.Apply(this);
+
+        return this;
+    }
+
+
+
+    /// <summary>
     /// Populates the specified DbSet with the provided entities.
     /// </summary>
     /// <param name="entities">The entities to populate the database with</param>

--- a/src/Wolfgang.DbContextBuilder-Core/ISeedProfile.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/ISeedProfile.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolfgang.DbContextBuilderCore;
+
+/// <summary>
+/// A reusable, named bundle of seed data that can be applied to any
+/// <see cref="DbContextBuilder{T}"/> in a single call via
+/// <see cref="DbContextBuilder{T}.UseSeedProfile(ISeedProfile{T})"/>.
+/// </summary>
+/// <typeparam name="T">The <see cref="DbContext"/> type the profile seeds.</typeparam>
+/// <remarks>
+/// Seed profiles encapsulate a complete set of seed entities so the same setup can be
+/// shared across many test classes instead of being re-built in each one. Implement
+/// <see cref="Apply"/> to call <c>SeedWith</c> one or more times on the supplied builder.
+/// </remarks>
+/// <example>
+/// <code>
+/// public sealed class StandardCatalogue : ISeedProfile&lt;ShopDbContext&gt;
+/// {
+///     public void Apply(DbContextBuilder&lt;ShopDbContext&gt; builder) =>
+///         builder.SeedWith(
+///             new Product { Name = "Widget" },
+///             new Product { Name = "Gadget" });
+/// }
+///
+/// await using var context = await new DbContextBuilder&lt;ShopDbContext&gt;()
+///     .UseInMemory()
+///     .UseSeedProfile(new StandardCatalogue())
+///     .BuildAsync();
+/// </code>
+/// </example>
+public interface ISeedProfile<T> where T : DbContext
+{
+    /// <summary>
+    /// Applies this profile's seed data to <paramref name="builder"/>, typically by
+    /// calling <c>SeedWith</c> one or more times.
+    /// </summary>
+    /// <param name="builder">The builder to seed.</param>
+    void Apply(DbContextBuilder<T> builder);
+}

--- a/src/Wolfgang.DbContextBuilder-Core/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.DbContextBuilder-Core/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.UseSeedProfile(Wolfgang.DbContextBuilderCore.ISeedProfile<T> profile) -> Wolfgang.DbContextBuilderCore.DbContextBuilder<T>
+Wolfgang.DbContextBuilderCore.ISeedProfile<T>
+Wolfgang.DbContextBuilderCore.ISeedProfile<T>.Apply(Wolfgang.DbContextBuilderCore.DbContextBuilder<T> builder) -> void

--- a/tests/Wolfgang.DbContextBuilder-Core-EF10.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF10.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF10.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF10.csproj
@@ -39,6 +39,7 @@
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\NoCircularReferencesCustomizationTests.cs" Link="NoCircularReferencesCustomizationTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteForMsSqlServerModelCustomizerTests.cs" Link="SqliteForMsSqlServerModelCustomizerTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteModelCustomizerTests.cs" Link="SqliteModelCustomizerTests.cs" />
+	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedProfileTests.cs" Link="SeedProfileTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs" Link="DbSetAssertionsTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteDbContextCreatorTests.cs" Link="SqliteDbContextCreatorTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\TestsWithDefaults.cs" Link="TestsWithDefaults.cs" />

--- a/tests/Wolfgang.DbContextBuilder-Core-EF6.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF6.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF6.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF6.csproj
@@ -40,6 +40,7 @@
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\NoCircularReferencesCustomizationTests.cs" Link="NoCircularReferencesCustomizationTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteForMsSqlServerModelCustomizerTests.cs" Link="SqliteForMsSqlServerModelCustomizerTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteModelCustomizerTests.cs" Link="SqliteModelCustomizerTests.cs" />
+	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedProfileTests.cs" Link="SeedProfileTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs" Link="DbSetAssertionsTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteDbContextCreatorTests.cs" Link="SqliteDbContextCreatorTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\TestsWithDefaults.cs" Link="TestsWithDefaults.cs" />

--- a/tests/Wolfgang.DbContextBuilder-Core-EF7.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF7.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF7.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF7.csproj
@@ -40,6 +40,7 @@
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\NoCircularReferencesCustomizationTests.cs" Link="NoCircularReferencesCustomizationTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteForMsSqlServerModelCustomizerTests.cs" Link="SqliteForMsSqlServerModelCustomizerTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteModelCustomizerTests.cs" Link="SqliteModelCustomizerTests.cs" />
+	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedProfileTests.cs" Link="SeedProfileTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs" Link="DbSetAssertionsTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteDbContextCreatorTests.cs" Link="SqliteDbContextCreatorTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\TestsWithDefaults.cs" Link="TestsWithDefaults.cs" />

--- a/tests/Wolfgang.DbContextBuilder-Core-EF8.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF8.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF8.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF8.csproj
@@ -39,6 +39,7 @@
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\NoCircularReferencesCustomizationTests.cs" Link="NoCircularReferencesCustomizationTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteForMsSqlServerModelCustomizerTests.cs" Link="SqliteForMsSqlServerModelCustomizerTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteModelCustomizerTests.cs" Link="SqliteModelCustomizerTests.cs" />
+	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedProfileTests.cs" Link="SeedProfileTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs" Link="DbSetAssertionsTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteDbContextCreatorTests.cs" Link="SqliteDbContextCreatorTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\TestsWithDefaults.cs" Link="TestsWithDefaults.cs" />

--- a/tests/Wolfgang.DbContextBuilder-Core-EF9.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF9.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF9.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF9.csproj
@@ -39,6 +39,7 @@
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\NoCircularReferencesCustomizationTests.cs" Link="NoCircularReferencesCustomizationTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteForMsSqlServerModelCustomizerTests.cs" Link="SqliteForMsSqlServerModelCustomizerTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteModelCustomizerTests.cs" Link="SqliteModelCustomizerTests.cs" />
+	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedProfileTests.cs" Link="SeedProfileTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs" Link="DbSetAssertionsTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteDbContextCreatorTests.cs" Link="SqliteDbContextCreatorTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\TestsWithDefaults.cs" Link="TestsWithDefaults.cs" />

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedProfileTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedProfileTests.cs
@@ -1,0 +1,101 @@
+using AdventureWorks.Models;
+
+namespace Wolfgang.DbContextBuilderCore.Tests.Unit;
+
+/// <summary>
+/// Tests for <see cref="DbContextBuilder{T}.UseSeedProfile"/> and
+/// <see cref="ISeedProfile{T}"/>.
+/// </summary>
+public class SeedProfileTests
+{
+    private sealed class TwoAddressesProfile : ISeedProfile<AdventureWorksDbContext>
+    {
+        public void Apply(DbContextBuilder<AdventureWorksDbContext> builder) =>
+            builder.SeedWith
+            (
+                MakeAddress(901, "1 First St"),
+                MakeAddress(902, "2 Second St")
+            );
+    }
+
+    private sealed class OneAddressProfile : ISeedProfile<AdventureWorksDbContext>
+    {
+        public void Apply(DbContextBuilder<AdventureWorksDbContext> builder) =>
+            builder.SeedWith(MakeAddress(903, "3 Third St"));
+    }
+
+    private static Address MakeAddress(int id, string line1) => new()
+    {
+        AddressId = id,
+        AddressLine1 = line1,
+        City = "Townsville",
+        StateProvinceId = 1,
+        PostalCode = "00001",
+        Rowguid = Guid.NewGuid(),
+        ModifiedDate = DateTime.UtcNow,
+    };
+
+
+
+    /// <summary>
+    /// Verifies that UseSeedProfile applies the seed data declared by the profile.
+    /// </summary>
+    [Fact]
+    public async Task UseSeedProfile_applies_the_profiles_seed_data()
+    {
+        using var sut = new DbContextBuilder<AdventureWorksDbContext>().UseInMemory();
+
+        await using var context = await sut
+            .UseSeedProfile(new TwoAddressesProfile())
+            .BuildAsync();
+
+        Assert.Equal(2, context.Addresses.Count());
+    }
+
+
+
+    /// <summary>
+    /// Verifies that UseSeedProfile returns the builder so calls can be chained.
+    /// </summary>
+    [Fact]
+    public void UseSeedProfile_returns_the_builder_for_chaining()
+    {
+        using var sut = new DbContextBuilder<AdventureWorksDbContext>().UseInMemory();
+
+        var result = sut.UseSeedProfile(new OneAddressProfile());
+
+        Assert.IsType<DbContextBuilder<AdventureWorksDbContext>>(result);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that UseSeedProfile with a null profile throws ArgumentNullException.
+    /// </summary>
+    [Fact]
+    public void UseSeedProfile_when_passed_null_throws_ArgumentNullException()
+    {
+        using var sut = new DbContextBuilder<AdventureWorksDbContext>().UseInMemory();
+
+        var ex = Assert.Throws<ArgumentNullException>(() => sut.UseSeedProfile(null!));
+        Assert.Equal("profile", ex.ParamName);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that applying multiple profiles accumulates their seed data.
+    /// </summary>
+    [Fact]
+    public async Task UseSeedProfile_when_multiple_profiles_applied_accumulates_their_seed_data()
+    {
+        using var sut = new DbContextBuilder<AdventureWorksDbContext>().UseInMemory();
+
+        await using var context = await sut
+            .UseSeedProfile(new TwoAddressesProfile())
+            .UseSeedProfile(new OneAddressProfile())
+            .BuildAsync();
+
+        Assert.Equal(3, context.Addresses.Count());
+    }
+}


### PR DESCRIPTION
Closes #104. First of the 0.8.0 "make seeded test contexts easy" milestone.

## What
- **`ISeedProfile<T>`** — implement `Apply(DbContextBuilder<T>)` to bundle a complete set of seed data.
- **`DbContextBuilder<T>.UseSeedProfile(ISeedProfile<T>)`** — apply a profile in one call; returns the builder for chaining. Multiple profiles **accumulate**.

```csharp
public sealed class StandardCatalogue : ISeedProfile<ShopDbContext>
{
    public void Apply(DbContextBuilder<ShopDbContext> builder) =>
        builder.SeedWith(new Product { Name = "Widget" }, new Product { Name = "Gadget" });
}

await using var context = await new DbContextBuilder<ShopDbContext>()
    .UseInMemory()
    .UseSeedProfile(new StandardCatalogue())
    .BuildAsync();
```

## Plumbing (per repo conventions)
- `ISeedProfile.cs` linked into the 5 Core-EFx **source** projects; `PublicAPI.Unshipped.txt` updated.
- `SeedProfileTests.cs` (apply / chaining-return / null-guard / multi-profile-accumulate) linked into all 5 EF-wrapper **test** projects so every wrapper assembly keeps full coverage.

## Verified locally
- Core builds clean in Release (PublicAPI/RS0017 satisfied).
- Seed-profile tests pass on the base Core and the EF8 wrapper (4/4).

Part of the milestone stack: this, then #117 (test output), #113 (time provider), #118 (Bogus), #103 (FK auto-wire).