### PR TITLE
feat: UseDiagnosticOutput for test diagnostic logging (closes #117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reusable, named bundles of seed data that can be applied to any builder in one call.
   Multiple profiles accumulate, so common setups can be shared across many test classes
   instead of being re-built in each. (#104)
+- New `DbContextBuilder<T>.UseDiagnosticOutput(Action<string>)` — routes EF Core logs
+  (including generated SQL) produced while building/seeding, plus a one-line seed summary,
+  to a caller-supplied sink. Framework-agnostic: pass `testOutputHelper.WriteLine` in xUnit
+  so the seeded context is visible in the log when a test fails. (#117)
 
 ### Changed
 

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
@@ -18,6 +18,7 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     private bool _disposed;
     private readonly List<object> _seedData = [];
     private DbContextOptionsBuilder<T>? _dbContextOptionsBuilder;
+    private Action<string>? _diagnosticOutput;
 
 
 
@@ -95,6 +96,27 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
         ArgumentNullException.ThrowIfNull(profile);
 
         profile.Apply(this);
+
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Routes diagnostic output to <paramref name="writeLine"/>: EF Core logs (including the
+    /// generated SQL) produced while creating and seeding the database, plus a one-line summary
+    /// of how many entity rows were seeded. Pass your test framework's output sink — for example
+    /// <c>UseDiagnosticOutput(testOutputHelper.WriteLine)</c> in xUnit — so the seeded context is
+    /// visible in the test log when an assertion fails.
+    /// </summary>
+    /// <param name="writeLine">Receives each diagnostic line.</param>
+    /// <returns><see cref="DbContextBuilder{T}"/></returns>
+    /// <exception cref="ArgumentNullException"><paramref name="writeLine"/> is null.</exception>
+    public DbContextBuilder<T> UseDiagnosticOutput(Action<string> writeLine)
+    {
+        ArgumentNullException.ThrowIfNull(writeLine);
+
+        _diagnosticOutput = writeLine;
 
         return this;
     }
@@ -336,6 +358,11 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
             optionBuilder.UseInternalServiceProvider(provider);
         }
 
+        if (_diagnosticOutput is not null)
+        {
+            optionBuilder.LogTo(_diagnosticOutput);
+        }
+
         var contextCreator = CreateDbContext ??= new InMemoryDbContextCreator();
 
         // Create a temporary context to initialize and seed the database, then dispose it
@@ -368,6 +395,11 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
                 await seedContext.SaveChangesAsync().ConfigureAwait(false);
             }
         }
+
+        _diagnosticOutput?.Invoke
+        (
+            $"DbContextBuilder<{typeof(T).Name}> built; seeded {_seedData.Count} entity row(s)."
+        );
 
         return await contextCreator.CreateDbContextAsync(optionBuilder).ConfigureAwait(false);
     }

--- a/src/Wolfgang.DbContextBuilder-Core/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.DbContextBuilder-Core/PublicAPI.Unshipped.txt
@@ -2,3 +2,4 @@
 Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.UseSeedProfile(Wolfgang.DbContextBuilderCore.ISeedProfile<T> profile) -> Wolfgang.DbContextBuilderCore.DbContextBuilder<T>
 Wolfgang.DbContextBuilderCore.ISeedProfile<T>
 Wolfgang.DbContextBuilderCore.ISeedProfile<T>.Apply(Wolfgang.DbContextBuilderCore.DbContextBuilder<T> builder) -> void
+Wolfgang.DbContextBuilderCore.DbContextBuilder<T>.UseDiagnosticOutput(System.Action<string> writeLine) -> Wolfgang.DbContextBuilderCore.DbContextBuilder<T>

--- a/tests/Wolfgang.DbContextBuilder-Core-EF10.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF10.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF10.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF10.csproj
@@ -40,6 +40,7 @@
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteForMsSqlServerModelCustomizerTests.cs" Link="SqliteForMsSqlServerModelCustomizerTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteModelCustomizerTests.cs" Link="SqliteModelCustomizerTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedProfileTests.cs" Link="SeedProfileTests.cs" />
+	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DiagnosticOutputTests.cs" Link="DiagnosticOutputTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs" Link="DbSetAssertionsTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteDbContextCreatorTests.cs" Link="SqliteDbContextCreatorTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\TestsWithDefaults.cs" Link="TestsWithDefaults.cs" />

--- a/tests/Wolfgang.DbContextBuilder-Core-EF6.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF6.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF6.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF6.csproj
@@ -41,6 +41,7 @@
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteForMsSqlServerModelCustomizerTests.cs" Link="SqliteForMsSqlServerModelCustomizerTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteModelCustomizerTests.cs" Link="SqliteModelCustomizerTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedProfileTests.cs" Link="SeedProfileTests.cs" />
+	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DiagnosticOutputTests.cs" Link="DiagnosticOutputTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs" Link="DbSetAssertionsTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteDbContextCreatorTests.cs" Link="SqliteDbContextCreatorTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\TestsWithDefaults.cs" Link="TestsWithDefaults.cs" />

--- a/tests/Wolfgang.DbContextBuilder-Core-EF7.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF7.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF7.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF7.csproj
@@ -41,6 +41,7 @@
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteForMsSqlServerModelCustomizerTests.cs" Link="SqliteForMsSqlServerModelCustomizerTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteModelCustomizerTests.cs" Link="SqliteModelCustomizerTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedProfileTests.cs" Link="SeedProfileTests.cs" />
+	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DiagnosticOutputTests.cs" Link="DiagnosticOutputTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs" Link="DbSetAssertionsTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteDbContextCreatorTests.cs" Link="SqliteDbContextCreatorTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\TestsWithDefaults.cs" Link="TestsWithDefaults.cs" />

--- a/tests/Wolfgang.DbContextBuilder-Core-EF8.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF8.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF8.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF8.csproj
@@ -40,6 +40,7 @@
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteForMsSqlServerModelCustomizerTests.cs" Link="SqliteForMsSqlServerModelCustomizerTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteModelCustomizerTests.cs" Link="SqliteModelCustomizerTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedProfileTests.cs" Link="SeedProfileTests.cs" />
+	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DiagnosticOutputTests.cs" Link="DiagnosticOutputTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs" Link="DbSetAssertionsTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteDbContextCreatorTests.cs" Link="SqliteDbContextCreatorTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\TestsWithDefaults.cs" Link="TestsWithDefaults.cs" />

--- a/tests/Wolfgang.DbContextBuilder-Core-EF9.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF9.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF9.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF9.csproj
@@ -40,6 +40,7 @@
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteForMsSqlServerModelCustomizerTests.cs" Link="SqliteForMsSqlServerModelCustomizerTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteModelCustomizerTests.cs" Link="SqliteModelCustomizerTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedProfileTests.cs" Link="SeedProfileTests.cs" />
+	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DiagnosticOutputTests.cs" Link="DiagnosticOutputTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs" Link="DbSetAssertionsTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteDbContextCreatorTests.cs" Link="SqliteDbContextCreatorTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\TestsWithDefaults.cs" Link="TestsWithDefaults.cs" />

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DiagnosticOutputTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/DiagnosticOutputTests.cs
@@ -1,0 +1,88 @@
+using AdventureWorks.Models;
+
+namespace Wolfgang.DbContextBuilderCore.Tests.Unit;
+
+/// <summary>
+/// Tests for <see cref="DbContextBuilder{T}.UseDiagnosticOutput"/>.
+/// </summary>
+public class DiagnosticOutputTests
+{
+    private static Address MakeAddress(int id) => new()
+    {
+        AddressId = id,
+        AddressLine1 = $"{id} Main St",
+        City = "Townsville",
+        StateProvinceId = 1,
+        PostalCode = "00001",
+        Rowguid = Guid.NewGuid(),
+        ModifiedDate = DateTime.UtcNow,
+    };
+
+
+
+    /// <summary>
+    /// Verifies that UseDiagnosticOutput writes a summary line reporting the seeded row count.
+    /// </summary>
+    [Fact]
+    public async Task UseDiagnosticOutput_writes_a_seed_summary()
+    {
+        var lines = new List<string>();
+        using var sut = new DbContextBuilder<AdventureWorksDbContext>().UseInMemory();
+
+        await using var context = await sut
+            .UseDiagnosticOutput(lines.Add)
+            .SeedWith(MakeAddress(1), MakeAddress(2))
+            .BuildAsync();
+
+        Assert.Contains(lines, line => line.Contains("seeded 2 entity row(s)", StringComparison.Ordinal));
+    }
+
+
+
+    /// <summary>
+    /// Verifies that EF Core's own diagnostic logs (not just the summary line) are captured.
+    /// </summary>
+    [Fact]
+    public async Task UseDiagnosticOutput_captures_ef_core_logs()
+    {
+        var lines = new List<string>();
+        using var sut = new DbContextBuilder<AdventureWorksDbContext>().UseInMemory();
+
+        await using var context = await sut
+            .UseDiagnosticOutput(lines.Add)
+            .SeedWith(MakeAddress(1))
+            .BuildAsync();
+
+        // At least one captured line is an EF Core log rather than the builder's own summary.
+        Assert.Contains(lines, line => !line.StartsWith("DbContextBuilder<", StringComparison.Ordinal));
+    }
+
+
+
+    /// <summary>
+    /// Verifies that UseDiagnosticOutput returns the builder so calls can be chained.
+    /// </summary>
+    [Fact]
+    public void UseDiagnosticOutput_returns_the_builder_for_chaining()
+    {
+        using var sut = new DbContextBuilder<AdventureWorksDbContext>().UseInMemory();
+
+        var result = sut.UseDiagnosticOutput(_ => { });
+
+        Assert.IsType<DbContextBuilder<AdventureWorksDbContext>>(result);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that UseDiagnosticOutput with a null sink throws ArgumentNullException.
+    /// </summary>
+    [Fact]
+    public void UseDiagnosticOutput_when_passed_null_throws_ArgumentNullException()
+    {
+        using var sut = new DbContextBuilder<AdventureWorksDbContext>().UseInMemory();
+
+        var ex = Assert.Throws<ArgumentNullException>(() => sut.UseDiagnosticOutput(null!));
+        Assert.Equal("writeLine", ex.ParamName);
+    }
+}


### PR DESCRIPTION
Closes #117. Milestone stack feature 2/5.

`DbContextBuilder<T>.UseDiagnosticOutput(Action<string> writeLine)` — when set, wires EF Core's `LogTo` into the sink (EF logs + generated SQL captured during build/seed/query) and emits a one-line seed summary.

**Framework-agnostic** (per our discussion): the consumer supplies the sink, so Core takes no xUnit dependency.
```csharp
await using var context = await new DbContextBuilder<ShopDbContext>()
    .UseInMemory()
    .UseDiagnosticOutput(testOutputHelper.WriteLine)   // xUnit
    .SeedWith(new Product { Name = "Widget" })
    .BuildAsync();
// log shows EF SQL + "DbContextBuilder<ShopDbContext> built; seeded 1 entity row(s)."
```

Verified: Core builds clean (PublicAPI satisfied); 4/4 tests pass on base + EF8 wrapper (incl. confirming real EF logs reach the sink). Tests linked into all 5 wrapper projects.