### PR TITLE
feat: Wolfgang.DbContextBuilder.Bogus random-data provider (closes #118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New **`Wolfgang.DbContextBuilder.Bogus`** package — a Bogus-backed `ICreateRandomEntities`
+  (`BogusRandomEntityCreator`) that auto-populates common scalar property types with
+  realistic-looking fake values. Plug in with
+  `builder.UseCustomRandomEntityCreator(new BogusRandomEntityCreator())`. (#118)
+
 - New **`Wolfgang.DbContextBuilder.Abstractions`** package containing `ICreateRandomEntities`,
   so add-on packages (e.g. an upcoming Bogus random-data provider) can target the family
   without taking a dependency on a specific EF Core version.

--- a/Wolfgang.DbContextBuilder.slnx
+++ b/Wolfgang.DbContextBuilder.slnx
@@ -23,6 +23,7 @@
     <Project Path="src/Wolfgang.DbContextBuilder-Core-EF8/Wolfgang.DbContextBuilder-Core-EF8.csproj" />
     <Project Path="src/Wolfgang.DbContextBuilder-Core-EF9/Wolfgang.DbContextBuilder-Core-EF9.csproj" />
     <Project Path="src/Wolfgang.DbContextBuilder-Core/Wolfgang.DbContextBuilder-Core.csproj" />
+    <Project Path="src/Wolfgang.DbContextBuilder.Bogus/Wolfgang.DbContextBuilder.Bogus.csproj" />
     <Project Path="src/Wolfgang.DbContextBuilder-EF6/Wolfgang.DbContextBuilder-EF6.csproj" />
   </Folder>
   <Folder Name="/Tests/">
@@ -32,6 +33,7 @@
     <Project Path="tests/Wolfgang.DbContextBuilder-Core-EF8.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF8.csproj" />
     <Project Path="tests/Wolfgang.DbContextBuilder-Core-EF9.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF9.csproj" />
     <Project Path="tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit.csproj" />
+    <Project Path="tests/Wolfgang.DbContextBuilder.Bogus.Tests.Unit/Wolfgang.DbContextBuilder.Bogus.Tests.Unit.csproj" />
     <Project Path="tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/Wolfgang.DbContextBuilder-EF6.Tests.Unit.csproj" />
   </Folder>
 </Solution>

--- a/src/Wolfgang.DbContextBuilder.Bogus/BogusRandomEntityCreator.cs
+++ b/src/Wolfgang.DbContextBuilder.Bogus/BogusRandomEntityCreator.cs
@@ -1,0 +1,52 @@
+using Bogus;
+
+namespace Wolfgang.DbContextBuilderCore;
+
+/// <summary>
+/// An <see cref="ICreateRandomEntities"/> implementation backed by
+/// <see href="https://github.com/bchavez/Bogus">Bogus</see>. It auto-populates the common
+/// scalar property types of an entity with realistic-looking fake values, leaving navigation
+/// and other reference-type properties unset (so seeding does not pull in object graphs).
+/// </summary>
+/// <remarks>
+/// Plug it in via the existing creator hook:
+/// <example>
+/// <code>
+/// await using var context = await new DbContextBuilder&lt;ShopDbContext&gt;()
+///     .UseInMemory()
+///     .UseCustomRandomEntityCreator(new BogusRandomEntityCreator())
+///     .SeedWithRandom&lt;Product&gt;(50)
+///     .BuildAsync();
+/// </code>
+/// </example>
+/// Entity types must expose a public parameterless constructor (Bogus instantiates them).
+/// </remarks>
+public class BogusRandomEntityCreator : ICreateRandomEntities
+{
+    /// <inheritdoc />
+    public IEnumerable<TEntity> CreateRandomEntities<TEntity>(int count) where TEntity : class
+    {
+        if (count < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count), "Count must be greater than 0");
+        }
+
+        // Bogus is non-strict by default: properties without a rule are left at their
+        // default value, so navigation/reference-type properties stay unset.
+        var faker = new Faker<TEntity>()
+            .RuleForType(typeof(string), f => f.Lorem.Word())
+            .RuleForType(typeof(bool), f => f.Random.Bool())
+            .RuleForType(typeof(byte), f => f.Random.Byte())
+            .RuleForType(typeof(short), f => f.Random.Short(1))
+            .RuleForType(typeof(int), f => f.Random.Int(1, 100_000))
+            .RuleForType(typeof(long), f => f.Random.Long(1))
+            .RuleForType(typeof(float), f => f.Random.Float())
+            .RuleForType(typeof(double), f => f.Random.Double())
+            .RuleForType(typeof(decimal), f => f.Random.Decimal(0, 100_000))
+            .RuleForType(typeof(Guid), f => f.Random.Guid())
+            .RuleForType(typeof(DateTime), f => f.Date.Past())
+            .RuleForType(typeof(DateTimeOffset), f => f.Date.PastOffset());
+
+        return faker.Generate(count);
+    }
+}

--- a/src/Wolfgang.DbContextBuilder.Bogus/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.DbContextBuilder.Bogus/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Wolfgang.DbContextBuilder.Bogus/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.DbContextBuilder.Bogus/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+#nullable enable
+Wolfgang.DbContextBuilderCore.BogusRandomEntityCreator
+Wolfgang.DbContextBuilderCore.BogusRandomEntityCreator.BogusRandomEntityCreator() -> void
+Wolfgang.DbContextBuilderCore.BogusRandomEntityCreator.CreateRandomEntities<TEntity>(int count) -> System.Collections.Generic.IEnumerable<TEntity>

--- a/src/Wolfgang.DbContextBuilder.Bogus/Wolfgang.DbContextBuilder.Bogus.csproj
+++ b/src/Wolfgang.DbContextBuilder.Bogus/Wolfgang.DbContextBuilder.Bogus.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<RootNamespace>Wolfgang.DbContextBuilderCore</RootNamespace>
+		<TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
+		<LangVersion>latest</LangVersion>
+		<Version>0.7.0</Version>
+		<!-- Pin AssemblyVersion to a fixed binding-stability baseline (see the Core csproj). -->
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
+		<Title>Wolfgang.DbContextBuilder Bogus provider</Title>
+		<Description>A Bogus-backed ICreateRandomEntities for Wolfgang.DbContextBuilder, producing realistic-looking fake values. Plug in with builder.UseCustomRandomEntityCreator(new BogusRandomEntityCreator()).</Description>
+		<PackageProjectUrl>https://github.com/Chris-Wolfgang/DbContextBuilder</PackageProjectUrl>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<RepositoryUrl>https://github.com/Chris-Wolfgang/DbContextBuilder</RepositoryUrl>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+		<PackageIcon>dbcontext-builder.png</PackageIcon>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+		<SignAssembly>False</SignAssembly>
+		<PackageTags></PackageTags>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<IsPackable>true</IsPackable>
+		<IsTestProject>false</IsTestProject>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Bogus" Version="35.6.5" />
+		<ProjectReference Include="..\Wolfgang.DbContextBuilder.Abstractions\Wolfgang.DbContextBuilder.Abstractions.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="..\..\README.md" Pack="True" PackagePath="/" />
+		<None Include="..\Wolfgang.DbContextBuilder-Core\Content\dbcontext-builder.png" Pack="true" PackagePath="/" />
+	</ItemGroup>
+</Project>

--- a/tests/Wolfgang.DbContextBuilder.Bogus.Tests.Unit/BogusRandomEntityCreatorTests.cs
+++ b/tests/Wolfgang.DbContextBuilder.Bogus.Tests.Unit/BogusRandomEntityCreatorTests.cs
@@ -1,0 +1,97 @@
+namespace Wolfgang.DbContextBuilderCore.Tests.Unit;
+
+/// <summary>
+/// Tests for <see cref="BogusRandomEntityCreator"/>.
+/// </summary>
+public class BogusRandomEntityCreatorTests
+{
+    // One property of every type BogusRandomEntityCreator has a rule for, so a single
+    // generation exercises every value generator.
+    private sealed class Sample
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public bool IsActive { get; set; }
+
+        public byte ByteValue { get; set; }
+
+        public short ShortValue { get; set; }
+
+        public int Id { get; set; }
+
+        public long LongValue { get; set; }
+
+        public float FloatValue { get; set; }
+
+        public double DoubleValue { get; set; }
+
+        public decimal Price { get; set; }
+
+        public Guid Reference { get; set; }
+
+        public DateTime CreatedOn { get; set; }
+
+        public DateTimeOffset UpdatedOn { get; set; }
+    }
+
+
+
+    /// <summary>
+    /// Verifies that the requested number of entities is generated.
+    /// </summary>
+    [Fact]
+    public void CreateRandomEntities_generates_the_requested_count()
+    {
+        var sut = new BogusRandomEntityCreator();
+
+        var items = sut.CreateRandomEntities<Sample>(10).ToList();
+
+        Assert.Equal(10, items.Count);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that common scalar properties are populated with fake values.
+    /// </summary>
+    [Fact]
+    public void CreateRandomEntities_populates_scalar_properties_with_fake_values()
+    {
+        var sut = new BogusRandomEntityCreator();
+
+        var item = sut.CreateRandomEntities<Sample>(1).Single();
+
+        Assert.False(string.IsNullOrEmpty(item.Name));
+        Assert.NotEqual(default, item.CreatedOn);
+        Assert.NotEqual(Guid.Empty, item.Reference);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that generated entities vary (random generation, not constant values).
+    /// </summary>
+    [Fact]
+    public void CreateRandomEntities_produces_varied_values_across_entities()
+    {
+        var sut = new BogusRandomEntityCreator();
+
+        var items = sut.CreateRandomEntities<Sample>(20).ToList();
+
+        Assert.Equal(20, items.Select(item => item.Reference).Distinct().Count());
+    }
+
+
+
+    /// <summary>
+    /// Verifies that a count below one throws ArgumentOutOfRangeException.
+    /// </summary>
+    [Fact]
+    public void CreateRandomEntities_when_count_is_less_than_one_throws_ArgumentOutOfRangeException()
+    {
+        var sut = new BogusRandomEntityCreator();
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => sut.CreateRandomEntities<Sample>(0));
+        Assert.Equal("count", ex.ParamName);
+    }
+}

--- a/tests/Wolfgang.DbContextBuilder.Bogus.Tests.Unit/Wolfgang.DbContextBuilder.Bogus.Tests.Unit.csproj
+++ b/tests/Wolfgang.DbContextBuilder.Bogus.Tests.Unit/Wolfgang.DbContextBuilder.Bogus.Tests.Unit.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<RootNamespace>Wolfgang.DbContextBuilderCore.Tests.Unit</RootNamespace>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<LangVersion>latest</LangVersion>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<!-- CA1707 (underscores) is intentional: test names follow MethodUnderTest_when_condition_expected_result. -->
+		<NoWarn>$(NoWarn);CA1707</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Wolfgang.DbContextBuilder.Bogus\Wolfgang.DbContextBuilder.Bogus.csproj" />
+	</ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+</Project>


### PR DESCRIPTION
Closes #118. **PR-2 of B2** — builds on the Abstractions package (#347, merged).

## What
New **`Wolfgang.DbContextBuilder.Bogus`** package with `BogusRandomEntityCreator : ICreateRandomEntities`, backed by [Bogus](https://github.com/bchavez/Bogus). It auto-populates common scalar property types (string, bool, byte/short/int/long/float/double/decimal, Guid, DateTime, DateTimeOffset) with realistic-looking fake values, leaving reference-type (navigation) properties unset so `SeedWithRandom` doesn't drag in object graphs.

```csharp
await using var context = await new DbContextBuilder<ShopDbContext>()
    .UseInMemory()
    .UseCustomRandomEntityCreator(new BogusRandomEntityCreator())
    .SeedWithRandom<Product>(50)
    .BuildAsync();
```

## Design (per our discussion — B2)
- References the **Abstractions** package, so one Bogus package works across all EF Core versions (no per-EF dependency).
- Wires in through the **existing** `UseCustomRandomEntityCreator(...)` — no new builder surface needed.

## Release impact
Adds **one shipped package** (8 → 9, on top of #347's Abstractions). New test project keeps the package at **100% coverage** for the per-project gate.

## Verified locally
- Bogus package + test project build clean (Release).
- 4/4 tests pass; `BogusRandomEntityCreator` line-rate = 1.0.