### PR TITLE
feat: auto-wire foreign keys when seeding random entities (closes #103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `SeedWithRandom` now reconciles foreign keys on the random entities against the EF model
+  at build time, so random FK values no longer violate referential constraints (which
+  matters for SQLite). A required FK is wired to a seeded principal of its type when one is
+  present; an optional FK with no seeded principal is set to `null`. Entities added with
+  `SeedWith` are never modified. (#103)
+
 ### Fixed
 
 ### Removed

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Wolfgang.DbContextBuilderCore;
@@ -17,6 +18,10 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
 {
     private bool _disposed;
     private readonly List<object> _seedData = [];
+    // Entities added via SeedWithRandom (reference identity). Their foreign keys are
+    // reconciled against the model at build time so random FK values don't violate
+    // constraints; explicitly-SeedWith'd entities are never touched.
+    private readonly HashSet<object> _randomlySeeded = new(ReferenceEqualityComparer.Instance);
     private DbContextOptionsBuilder<T>? _dbContextOptionsBuilder;
     private Action<string>? _diagnosticOutput;
 
@@ -276,7 +281,14 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
         var entities = RandomEntityCreator
             .CreateRandomEntities<TEntity>(count);
 
-        _seedData.AddRange(entities);
+        // Materialise once (the func overloads use a lazy Select) and record the entities
+        // as randomly seeded so their foreign keys are reconciled at build time.
+        var materialized = entities as IReadOnlyList<TEntity> ?? entities.ToList();
+        _seedData.AddRange(materialized);
+        foreach (var entity in materialized)
+        {
+            _randomlySeeded.Add(entity);
+        }
 
         return this;
     }
@@ -304,7 +316,14 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
             .CreateRandomEntities<TEntity>(count)
             .Select(func);
 
-        _seedData.AddRange(entities);
+        // Materialise once (the func overloads use a lazy Select) and record the entities
+        // as randomly seeded so their foreign keys are reconciled at build time.
+        var materialized = entities as IReadOnlyList<TEntity> ?? entities.ToList();
+        _seedData.AddRange(materialized);
+        foreach (var entity in materialized)
+        {
+            _randomlySeeded.Add(entity);
+        }
 
         return this;
     }
@@ -332,9 +351,121 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
             .CreateRandomEntities<TEntity>(count)
             .Select(func);
 
-        _seedData.AddRange(entities);
+        // Materialise once (the func overloads use a lazy Select) and record the entities
+        // as randomly seeded so their foreign keys are reconciled at build time.
+        var materialized = entities as IReadOnlyList<TEntity> ?? entities.ToList();
+        _seedData.AddRange(materialized);
+        foreach (var entity in materialized)
+        {
+            _randomlySeeded.Add(entity);
+        }
 
         return this;
+    }
+
+
+
+    /// <summary>
+    /// Reconciles foreign keys on randomly-seeded entities against the model so that the
+    /// random FK values produced by the random-entity creator do not violate referential
+    /// constraints (which matters for providers that enforce them, e.g. SQLite). For each
+    /// foreign key on a randomly-seeded dependent: if a different seeded entity of the
+    /// principal type is present, the dependent's FK is set to that principal's key; otherwise
+    /// an optional FK is set to <c>null</c>. Required FKs with no available principal are left
+    /// untouched (best effort). Entities added via <c>SeedWith</c> are never modified.
+    /// </summary>
+    /// <param name="context">A context whose model is used to resolve the relationships.</param>
+    private void ReconcileRandomForeignKeys(DbContext context)
+    {
+        if (_randomlySeeded.Count == 0)
+        {
+            return;
+        }
+
+        var seededByType = new Dictionary<Type, List<object>>();
+        foreach (var entity in _seedData)
+        {
+            var type = entity.GetType();
+            if (!seededByType.TryGetValue(type, out var list))
+            {
+                list = [];
+                seededByType[type] = list;
+            }
+
+            list.Add(entity);
+        }
+
+        foreach (var dependent in _randomlySeeded)
+        {
+            var entityType = context.Model.FindEntityType(dependent.GetType());
+            if (entityType is null)
+            {
+                continue;
+            }
+
+            foreach (var foreignKey in entityType.GetForeignKeys())
+            {
+                ReconcileForeignKey(dependent, foreignKey, seededByType);
+            }
+        }
+    }
+
+
+
+    private static void ReconcileForeignKey
+    (
+        object dependent,
+        IForeignKey foreignKey,
+        IReadOnlyDictionary<Type, List<object>> seededByType
+    )
+    {
+        var principal = FindPrincipal(dependent, foreignKey, seededByType);
+
+        if (principal is not null)
+        {
+            // Point the dependent's FK properties at the chosen principal's key values.
+            var fkProperties = foreignKey.Properties;
+            var principalKeyProperties = foreignKey.PrincipalKey.Properties;
+            for (var i = 0; i < fkProperties.Count; i++)
+            {
+                var keyValue = principalKeyProperties[i].PropertyInfo?.GetValue(principal);
+                fkProperties[i].PropertyInfo?.SetValue(dependent, keyValue);
+            }
+        }
+        else if (!foreignKey.IsRequired)
+        {
+            // Optional relationship with no principal to point at — clear the random value.
+            foreach (var property in foreignKey.Properties)
+            {
+                property.PropertyInfo?.SetValue(dependent, value: null);
+            }
+        }
+    }
+
+
+
+    private static object? FindPrincipal
+    (
+        object dependent,
+        IForeignKey foreignKey,
+        IReadOnlyDictionary<Type, List<object>> seededByType
+    )
+    {
+        if (!seededByType.TryGetValue(foreignKey.PrincipalEntityType.ClrType, out var candidates))
+        {
+            return null;
+        }
+
+        // Prefer a principal that is not the dependent itself (handles self-referencing FKs).
+        foreach (var candidate in candidates)
+        {
+            if (!ReferenceEquals(candidate, dependent))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
     }
 
 
@@ -391,6 +522,7 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
 
             if (_seedData.Count > 0)
             {
+                ReconcileRandomForeignKeys(seedContext);
                 seedContext.AddRange(_seedData.AsEnumerable());
                 await seedContext.SaveChangesAsync().ConfigureAwait(false);
             }

--- a/tests/Wolfgang.DbContextBuilder-Core-EF10.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF10.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF10.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF10.csproj
@@ -39,6 +39,7 @@
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\NoCircularReferencesCustomizationTests.cs" Link="NoCircularReferencesCustomizationTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteForMsSqlServerModelCustomizerTests.cs" Link="SqliteForMsSqlServerModelCustomizerTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteModelCustomizerTests.cs" Link="SqliteModelCustomizerTests.cs" />
+	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/ForeignKeyAutoWireTests.cs" Link="ForeignKeyAutoWireTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedProfileTests.cs" Link="SeedProfileTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DiagnosticOutputTests.cs" Link="DiagnosticOutputTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs" Link="DbSetAssertionsTests.cs" />

--- a/tests/Wolfgang.DbContextBuilder-Core-EF6.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF6.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF6.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF6.csproj
@@ -40,6 +40,7 @@
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\NoCircularReferencesCustomizationTests.cs" Link="NoCircularReferencesCustomizationTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteForMsSqlServerModelCustomizerTests.cs" Link="SqliteForMsSqlServerModelCustomizerTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteModelCustomizerTests.cs" Link="SqliteModelCustomizerTests.cs" />
+	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/ForeignKeyAutoWireTests.cs" Link="ForeignKeyAutoWireTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedProfileTests.cs" Link="SeedProfileTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DiagnosticOutputTests.cs" Link="DiagnosticOutputTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs" Link="DbSetAssertionsTests.cs" />

--- a/tests/Wolfgang.DbContextBuilder-Core-EF7.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF7.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF7.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF7.csproj
@@ -40,6 +40,7 @@
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\NoCircularReferencesCustomizationTests.cs" Link="NoCircularReferencesCustomizationTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteForMsSqlServerModelCustomizerTests.cs" Link="SqliteForMsSqlServerModelCustomizerTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteModelCustomizerTests.cs" Link="SqliteModelCustomizerTests.cs" />
+	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/ForeignKeyAutoWireTests.cs" Link="ForeignKeyAutoWireTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedProfileTests.cs" Link="SeedProfileTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DiagnosticOutputTests.cs" Link="DiagnosticOutputTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs" Link="DbSetAssertionsTests.cs" />

--- a/tests/Wolfgang.DbContextBuilder-Core-EF8.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF8.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF8.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF8.csproj
@@ -39,6 +39,7 @@
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\NoCircularReferencesCustomizationTests.cs" Link="NoCircularReferencesCustomizationTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteForMsSqlServerModelCustomizerTests.cs" Link="SqliteForMsSqlServerModelCustomizerTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteModelCustomizerTests.cs" Link="SqliteModelCustomizerTests.cs" />
+	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/ForeignKeyAutoWireTests.cs" Link="ForeignKeyAutoWireTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedProfileTests.cs" Link="SeedProfileTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DiagnosticOutputTests.cs" Link="DiagnosticOutputTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs" Link="DbSetAssertionsTests.cs" />

--- a/tests/Wolfgang.DbContextBuilder-Core-EF9.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF9.csproj
+++ b/tests/Wolfgang.DbContextBuilder-Core-EF9.Tests.Unit/Wolfgang.DbContextBuilder-Core.Tests.Unit-EF9.csproj
@@ -39,6 +39,7 @@
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\NoCircularReferencesCustomizationTests.cs" Link="NoCircularReferencesCustomizationTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteForMsSqlServerModelCustomizerTests.cs" Link="SqliteForMsSqlServerModelCustomizerTests.cs" />
 	  <Compile Include="..\Wolfgang.DbContextBuilder-Core.Tests.Unit\SqliteModelCustomizerTests.cs" Link="SqliteModelCustomizerTests.cs" />
+	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/ForeignKeyAutoWireTests.cs" Link="ForeignKeyAutoWireTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedProfileTests.cs" Link="SeedProfileTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DiagnosticOutputTests.cs" Link="DiagnosticOutputTests.cs" />
 	  <Compile Include="../Wolfgang.DbContextBuilder-Core.Tests.Unit/DbSetAssertionsTests.cs" Link="DbSetAssertionsTests.cs" />

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/ForeignKeyAutoWireTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/ForeignKeyAutoWireTests.cs
@@ -1,0 +1,109 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore;
+
+namespace Wolfgang.DbContextBuilderCore.Tests.Unit;
+
+/// <summary>
+/// Tests that <c>SeedWithRandom</c> reconciles foreign keys on the random entities so they
+/// satisfy referential constraints (verified against SQLite, which enforces them).
+/// </summary>
+public class ForeignKeyAutoWireTests
+{
+    /// <summary>
+    /// Verifies that a required FK on a randomly-seeded dependent is wired to a seeded
+    /// principal, and an optional FK with no seeded principal is nulled — so the build does
+    /// not violate SQLite's foreign-key constraints.
+    /// </summary>
+    [Fact]
+    public async Task SeedWithRandom_wires_required_fk_to_seeded_principal_and_nulls_optional_fk()
+    {
+        using var sut = new DbContextBuilder<FactoryContext>().UseSqlite();
+
+        await using var context = await sut
+            .SeedWithRandom<Manufacturer>(2)
+            .SeedWithRandom<Widget>(3)
+            .BuildAsync();
+
+        var manufacturerIds = context.Manufacturers.Select(m => m.Id).ToHashSet();
+        var widgets = context.Widgets.ToList();
+
+        Assert.Equal(3, widgets.Count);
+        Assert.All(widgets, widget => Assert.Contains(widget.ManufacturerId, manufacturerIds));
+        Assert.All(widgets, widget => Assert.Null(widget.SupplierId));
+    }
+
+
+
+    /// <summary>
+    /// Verifies that entities added with <c>SeedWith</c> are never reconciled — their
+    /// explicit foreign-key values are preserved exactly.
+    /// </summary>
+    [Fact]
+    public async Task SeedWith_explicit_entities_are_left_untouched()
+    {
+        var manufacturer = new Manufacturer { Id = 100, Name = "Acme" };
+        var widget = new Widget { Id = 1, Name = "Cog", ManufacturerId = 100, SupplierId = 55 };
+
+        using var sut = new DbContextBuilder<FactoryContext>().UseInMemory();
+
+        await using var context = await sut
+            .SeedWith(manufacturer)
+            .SeedWith(widget)
+            .BuildAsync();
+
+        var stored = context.Widgets.Single();
+        Assert.Equal(100, stored.ManufacturerId);
+        Assert.Equal(55, stored.SupplierId);
+    }
+}
+
+
+
+[ExcludeFromCodeCoverage(Justification = "Test model")]
+internal class Manufacturer
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+}
+
+
+
+[ExcludeFromCodeCoverage(Justification = "Test model")]
+internal class Supplier
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+}
+
+
+
+[ExcludeFromCodeCoverage(Justification = "Test model")]
+internal class Widget
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public int ManufacturerId { get; set; }
+
+    // Virtual so the AutoFixture creator ignores it (leaving only the scalar FK random).
+    public virtual Manufacturer? Manufacturer { get; set; }
+
+    public int? SupplierId { get; set; }
+
+    public virtual Supplier? Supplier { get; set; }
+}
+
+
+
+[ExcludeFromCodeCoverage(Justification = "Test model")]
+internal class FactoryContext(DbContextOptions<FactoryContext> options) : DbContext(options)
+{
+    public DbSet<Manufacturer> Manufacturers => Set<Manufacturer>();
+
+    public DbSet<Supplier> Suppliers => Set<Supplier>();
+
+    public DbSet<Widget> Widgets => Set<Widget>();
+}


### PR DESCRIPTION
Closes #103. **Final feature of the "make seeded test contexts easy" milestone.**

## Problem
`SeedWithRandom<Order>(10)` makes entities with random scalar FK values (e.g. a random `CustomerId`) that reference no real row — so seeding into a constraint-enforcing provider (SQLite) throws.

## Fix
At build time the builder reconciles foreign keys on the **randomly-seeded** entities against `context.Model`:
- **required FK** → wired to a seeded principal of the matching type (if one was seeded);
- **optional FK** with no seeded principal → set to `null`;
- **required FK** with no available principal → left as-is (best effort).

Random entities are tracked by reference identity inside `SeedWithRandom`; **entities added via `SeedWith` are never touched**, so explicit FK values are preserved. Composite keys and self-references are handled. FK scalars are set from the principal's key (the random creator already populates principal keys, so there's no store-generated-key dependency).

```csharp
await using var context = await new DbContextBuilder<ShopDbContext>()
    .UseSqlite()
    .SeedWithRandom<Customer>(5)
    .SeedWithRandom<Order>(20)   // each Order's required CustomerId now points at a seeded Customer
    .BuildAsync();
```

## Notes
- **No public API change** (reconcile is internal to `BuildAsync`; `SeedWithRandom` signatures unchanged).
- Verified locally: 2 new tests pass on base Core + EF8 wrapper (required-wire + optional-null on SQLite; explicit entities untouched). `DbContextBuilder<T>` stays ~97% coverage.

This completes the milestone: #104, #117, #118, #103 delivered; #113 deferred (documented); #349 filed for the AutoFixture-extraction follow-up.