### PR TITLE
docs: document SeedWithRandom foreign-key reconciliation (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `SeedWithRandom` now reconciles foreign keys on the random entities against the EF model
-  at build time, so random FK values no longer violate referential constraints (which
-  matters for SQLite). A required FK is wired to a seeded principal of its type when one is
-  present; an optional FK with no seeded principal is set to `null`. Entities added with
-  `SeedWith` are never modified. (#103)
+- **`SeedWithRandom` now reconciles foreign keys on the random entities** against the EF
+  model at build time, so the random FK values no longer violate referential constraints
+  (which matters for SQLite, which enforces them). For each foreign key on a randomly-seeded
+  entity:
+  - a **required** FK is wired to a seeded principal of its type when one is present (so seed
+    the principals too, e.g. `.SeedWithRandom<Customer>(5).SeedWithRandom<Order>(20)`);
+  - an **optional** FK with no seeded principal is set to `null`;
+  - a **required** FK with no seeded principal is left as the random value (still fails on a
+    constraint-enforcing provider — seed the principal).
+
+  **Behavior change to be aware of:** the foreign-key values on a randomly-seeded entity are
+  no longer the raw random values the generator produced — a previously-random `SupplierId`
+  may now be `null`, and a `CustomerId` may now match a seeded customer. Tests that asserted
+  on those raw random FK values will see different values. Entities added with `SeedWith`
+  (explicit) are never modified, so their FK values are preserved exactly. (#103)
 
 ### Fixed
 

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -51,6 +51,31 @@ Two ways to seed:
 
 `SeedWith` and `SeedWithRandom` are chainable in any order. The builder accumulates all seeds and inserts them when `BuildAsync()` runs.
 
+### Random data and foreign keys
+
+`SeedWithRandom` fills scalar properties with random values, which means a raw foreign-key
+column points at nothing. To keep that from violating referential constraints (SQLite
+enforces them), the builder **reconciles foreign keys on randomly-seeded entities** at build
+time:
+
+- a **required** FK is wired to a seeded principal of its type — so seed the principals too:
+
+  ```csharp
+  await using var context = await new DbContextBuilder<ShopDbContext>()
+      .UseSqlite()
+      .SeedWithRandom<Customer>(5)   // seed the principals...
+      .SeedWithRandom<Order>(20)     // ...and each Order's CustomerId is wired to one of them
+      .BuildAsync();
+  ```
+
+- an **optional** FK with no seeded principal is set to `null`;
+- a **required** FK with no seeded principal of its type is left as the random value (so it
+  would still fail on a constraint-enforcing provider — the fix is to seed the principal).
+
+> **This may be a little unexpected, even though it's correct:** the foreign-key values on a
+> randomly-seeded entity are **not** the raw random values the generator produced. Entities you
+> add with `SeedWith` are never touched — their explicit FK values are preserved exactly.
+
 ## 5. Customize the model (SQLite for SQL Server only)
 
 `SqliteModelCustomizer` exposes hooks to override the schema-renaming heuristic, the default-value SQL translation, the computed-column handling, and the many-to-many join-table renaming. See the [API reference](../api/Wolfgang.DbContextBuilderCore.SqliteModelCustomizer.html) for the exact signatures.

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
@@ -267,6 +267,13 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// <summary>
     /// Populates the specified DbSet with random entities of type TEntity.
     /// </summary>
+    /// <remarks>
+    /// Foreign keys on the generated entities are reconciled against the model when the
+    /// context is built: a required FK is wired to a seeded principal of its type (so seed the
+    /// principals too), and an optional FK with no seeded principal is set to <c>null</c>. The
+    /// FK values on a randomly-seeded entity are therefore not the raw random values produced
+    /// by the creator. Entities added via <c>SeedWith</c> are never reconciled.
+    /// </remarks>
     /// <param name="count">The number of items to create</param>
     /// <typeparam name="TEntity">The type of entity to create</typeparam>
     /// <returns><see cref="DbContextBuilder{T}"/></returns>
@@ -298,6 +305,13 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// <summary>
     /// Populates the specified DbSet with random entities of type TEntity.
     /// </summary>
+    /// <remarks>
+    /// Foreign keys on the generated entities are reconciled against the model when the
+    /// context is built: a required FK is wired to a seeded principal of its type (so seed the
+    /// principals too), and an optional FK with no seeded principal is set to <c>null</c>. The
+    /// FK values on a randomly-seeded entity are therefore not the raw random values produced
+    /// by the creator. Entities added via <c>SeedWith</c> are never reconciled.
+    /// </remarks>
     /// <param name="count">The number of items to create</param>
     /// <param name="func">A function that takes a TEntity and returns an updated TEntity</param>
     /// <typeparam name="TEntity">The type of entity to create</typeparam>
@@ -333,6 +347,13 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// <summary>
     /// Populates the specified DbSet with random entities of type TEntity.
     /// </summary>
+    /// <remarks>
+    /// Foreign keys on the generated entities are reconciled against the model when the
+    /// context is built: a required FK is wired to a seeded principal of its type (so seed the
+    /// principals too), and an optional FK with no seeded principal is set to <c>null</c>. The
+    /// FK values on a randomly-seeded entity are therefore not the raw random values produced
+    /// by the creator. Entities added via <c>SeedWith</c> are never reconciled.
+    /// </remarks>
     /// <param name="count">The number of items to create</param>
     /// <param name="func">A function that takes a TEntity and the index number of the entity and returns an updated TEntity</param>
     /// <typeparam name="TEntity">The type of entity to create</typeparam>


### PR DESCRIPTION
Documents the #103 FK auto-wiring behavior in three places so users aren't surprised by it (it changes the FK values `SeedWithRandom` produces — correct, but unexpected).

- **Release notes (CHANGELOG):** expanded the #103 entry with the per-FK rules and an explicit **'behavior change to be aware of'** note (a previously-random `SupplierId` may now be `null`; tests asserting on raw random FK values will see different values).
- **getting-started docs:** new *'Random data and foreign keys'* subsection — the seed-the-principals example plus the caveat that randomly-seeded FK values are not the raw generated values, and `SeedWith` entities are never touched.
- **XML docs:** `SeedWithRandom` overloads now describe the reconciliation (shows in IntelliSense and the API reference).

Documentation only — no behavior or API change. Core builds clean (XML docs well-formed).