### PR TITLE
fix: dispose abandoned SQLite creator on provider re-selection; ctor-init m2m delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Re-selecting a database provider on a builder (e.g. `UseSqlite()` then `UseInMemory()`, or
+  calling a SQLite extension twice) now disposes the previously-configured creator instead of
+  abandoning it — the prior `SqliteDbContextCreator`'s open in-memory connection is no longer
+  leaked.
+- `SqliteModelCustomizer.OverrideManyToManyTableHandling` is now initialized in the constructor
+  rather than lazily in the getter, removing a `??=` race that could allocate duplicate default
+  delegates during concurrent model customization (matching the other override delegates fixed
+  in 0.7.0).
+
 ### Removed
 
 - **BREAKING — `UseAutoFixture()` and `AutoFixtureRandomEntityCreator` moved out of the EF Core

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
@@ -66,8 +66,24 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// </remarks>
     public DbContextBuilder<T> UseInMemory()
     {
-        CreateDbContext = new InMemoryDbContextCreator();
+        SetCreateDbContext(new InMemoryDbContextCreator());
         return this;
+    }
+
+
+
+    // Replaces the active DbContext creator, disposing the previous one if it owns resources
+    // (e.g. the SQLite creator holds an open in-memory connection). Provider selection is
+    // last-write-wins, so without this, re-selecting a provider on one builder would leak the
+    // abandoned creator's connection.
+    internal void SetCreateDbContext(ICreateDbContext creator)
+    {
+        if (!ReferenceEquals(CreateDbContext, creator) && CreateDbContext is IDisposable previous)
+        {
+            previous.Dispose();
+        }
+
+        CreateDbContext = creator;
     }
 
 

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderSqliteExtensions.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderSqliteExtensions.cs
@@ -86,7 +86,7 @@ public static class DbContextBuilderSqliteExtensions
         }
 
         builder.ServiceCollection.AddSingleton(typeof(IModelCustomizer), modelCustomizerType);
-        builder.CreateDbContext = new SqliteDbContextCreator();
+        builder.SetCreateDbContext(new SqliteDbContextCreator());
 
         return builder;
     }

--- a/src/Wolfgang.DbContextBuilder-Core/SqliteDbContextCreator.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/SqliteDbContextCreator.cs
@@ -16,6 +16,13 @@ internal sealed class SqliteDbContextCreator : ICreateDbContext, IDisposable
 
 
     /// <summary>
+    /// Whether <see cref="Dispose"/> has been called (and the underlying connection closed).
+    /// </summary>
+    internal bool IsDisposed { get; private set; }
+
+
+
+    /// <summary>
     /// Initializes a new instance and opens an in-memory SQLite connection.
     /// </summary>
     public SqliteDbContextCreator()
@@ -40,6 +47,12 @@ internal sealed class SqliteDbContextCreator : ICreateDbContext, IDisposable
     /// </summary>
     public void Dispose()
     {
+        if (IsDisposed)
+        {
+            return;
+        }
+
         _connection.Dispose();
+        IsDisposed = true;
     }
 }

--- a/src/Wolfgang.DbContextBuilder-Core/SqliteModelCustomizer.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/SqliteModelCustomizer.cs
@@ -141,6 +141,11 @@ public class SqliteModelCustomizer : ModelCustomizer
                 ? newDefaultValue
                 : defaultValue;
         };
+
+        // Initialize in the ctor (not lazily in the getter) so concurrent model
+        // customization can't race on a `??=` and allocate duplicate delegates —
+        // matching the other override delegates above.
+        _overrideManyToManyTableHandling = DefaultOverrideManyToManyTableHandling;
     }
 
 
@@ -257,7 +262,7 @@ public class SqliteModelCustomizer : ModelCustomizer
 
 
 
-    private Action<IMutableEntityType>? _overrideManyToManyTableHandling;
+    private Action<IMutableEntityType> _overrideManyToManyTableHandling;
 
     /// <summary>
     /// This action is called for each entity type to handle many-to-many join table renaming.
@@ -271,8 +276,7 @@ public class SqliteModelCustomizer : ModelCustomizer
     /// </remarks>
     public Action<IMutableEntityType> OverrideManyToManyTableHandling
     {
-        get =>
-            _overrideManyToManyTableHandling ??= DefaultOverrideManyToManyTableHandling;
+        get => _overrideManyToManyTableHandling;
         set => _overrideManyToManyTableHandling = value ?? throw new ArgumentNullException(nameof(value));
     }
 

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteDbContextCreatorTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteDbContextCreatorTests.cs
@@ -59,4 +59,48 @@ public class SqliteDbContextCreatorTests
         sut.Dispose();
         sut.Dispose();
     }
+
+
+
+    /// <summary>
+    /// Verifies that <see cref="SqliteDbContextCreator.IsDisposed"/> tracks disposal state and
+    /// that Dispose is idempotent.
+    /// </summary>
+    [Fact]
+    public void IsDisposed_is_false_until_disposed_then_true()
+    {
+        // Arrange
+        var sut = new SqliteDbContextCreator();
+        Assert.False(sut.IsDisposed);
+
+        // Act
+        sut.Dispose();
+
+        // Assert
+        Assert.True(sut.IsDisposed);
+
+        // Idempotent — a second Dispose stays disposed without throwing.
+        sut.Dispose();
+        Assert.True(sut.IsDisposed);
+    }
+
+
+
+    /// <summary>
+    /// Verifies that re-selecting a provider on a builder disposes the previous SQLite creator
+    /// (which holds an open in-memory connection) rather than leaking it.
+    /// </summary>
+    [Fact]
+    public void Reselecting_a_provider_disposes_the_previous_Sqlite_creator()
+    {
+        // Arrange — first provider is SQLite, which owns an open connection
+        using var builder = new DbContextBuilder<BasicContext>().UseSqlite();
+        var firstCreator = Assert.IsType<SqliteDbContextCreator>(builder.CreateDbContext);
+
+        // Act — last-write-wins provider selection abandons the SQLite creator
+        builder.UseInMemory();
+
+        // Assert — the abandoned creator was disposed, not leaked
+        Assert.True(firstCreator.IsDisposed);
+    }
 }


### PR DESCRIPTION
Two correctness fixes found during a full code-review pass on `vNext`.

## 1. SQLite connection leak on provider re-selection (`should-fix`)
Provider selection is last-write-wins, but re-selecting a provider on a builder — `UseSqlite()` then `UseInMemory()`, or a SQLite extension called twice — replaced the active `ICreateDbContext` **without disposing the previous one**. `SqliteDbContextCreator` holds an open in-memory `SqliteConnection`, so the abandoned creator leaked it.

- Added `DbContextBuilder.SetCreateDbContext(...)` — disposes the prior creator when it's `IDisposable` before swapping. `UseInMemory()` and the SQLite extension both route through it.
- Added an internal `IsDisposed` flag (idempotent `Dispose`) on `SqliteDbContextCreator`.
- Tests: `IsDisposed` state/idempotency + re-selection disposes the abandoned creator.

## 2. `OverrideManyToManyTableHandling` lazy-init race (`should-fix`)
The delegate was initialized lazily in the getter via `??=`, reintroducing the duplicate-delegate race that 0.7.0 fixed for the other three override delegates. Now constructor-initialized like its siblings; getter no longer mutates.

## Verification
`dotnet build -c Release` clean (warnings-as-errors); Core tests green (72, +2 new). CHANGELOG `Fixed` entries added.

Part of a 3-PR review-findings stack onto `vNext` (code fixes / build hygiene / docs). These are independent and can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
