### PR TITLE
docs: refresh README + copilot-instructions for the 0.8.0 package family

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,18 +4,18 @@ Always reference these instructions first and only fallback to search or additio
 
 ## Repository Summary
 
-**DbContextBuilder** is a .NET 8.0 library that uses the Builder pattern to create Entity Framework Core DbContext instances with an in-memory database for testing purposes. The library allows developers to easily set up DbContext instances with predefined and random data, making it ideal for unit tests and integration tests without relying on actual databases.
+**DbContextBuilder** is a .NET library family that uses the Builder pattern to create Entity Framework Core (and classic EF 6) DbContext instances with an in-memory database for testing purposes. The library allows developers to easily set up DbContext instances with predefined and random data, making it ideal for unit tests and integration tests without relying on actual databases.
 
-**Repository Type**: .NET Library  
-**Target Platform**: .NET 8.0  
+**Repository Type**: .NET Library (multi-package family)  
+**Target Platform**: net10.0 for the canonical Core package; per-EF-version wrappers target net6.0–net10.0; classic EF 6 targets net462–net481  
 **Primary Language**: C#  
-**NuGet Package**: Wolfgang.DbContextBuilder  
-**Main Features**: Builder pattern, in-memory database seeding, random data generation
+**NuGet Packages**: a family of 10 — `Wolfgang.DbContextBuilder-Core`, the per-EF-version wrappers `-Core-EF6/7/8/9/10`, classic `-EF6`, the shared `.Abstractions`, and the random-data providers `.AutoFixture` and `.Bogus` (each adds a `UseAutoFixture()`/`UseBogus()` extension; the EF Core packages no longer bundle a random-data provider).  
+**Main Features**: Builder pattern, in-memory/SQLite database seeding, pluggable random data generation, seed profiles, diagnostic output
 
 ## Build and Validation Instructions
 
 ### Prerequisites
-- .NET 8.0.x SDK (always verify: `dotnet --version`)
+- .NET 10.0.x SDK (required for the net10.0 targets; always verify: `dotnet --version`)
 - ReportGenerator tool: `dotnet tool install -g dotnet-reportgenerator-globaltool`
 - DevSkim CLI: `dotnet tool install --global Microsoft.CST.DevSkim.CLI`
 
@@ -49,8 +49,8 @@ Run these commands in the repository root in this exact order:
    ```bash
    cat CoverageReport/Summary.txt
    ```
-   - **REQUIREMENT**: Line coverage must be ≥ 80% for CI to pass
-   - Current baseline: ~76% (needs improvement for CI)
+   - **REQUIREMENT**: the coverage gate is **per-module (assembly), ≥ 90%** — every shippable
+     package's coverage is checked individually, aggregated across all test projects
 
 6. **Security Scanning** (< 1 second):
    ```bash

--- a/README.md
+++ b/README.md
@@ -26,9 +26,18 @@ DbContextBuilder ships as a family of packages — install the one that matches 
 | [`Wolfgang.DbContextBuilder-Core-EF10`](https://www.nuget.org/packages/Wolfgang.DbContextBuilder-Core-EF10) | EF Core 10 | Pins EF Core 10. |
 | [`Wolfgang.DbContextBuilder-EF6`](https://www.nuget.org/packages/Wolfgang.DbContextBuilder-EF6) | Classic EF 6 (non-Core) | For applications still on `System.Data.Entity` / EF 6.x. |
 
+Random-data and shared add-on packages (install alongside your EF Core package):
+
+| Package | Role |
+|---|---|
+| [`Wolfgang.DbContextBuilder.AutoFixture`](https://www.nuget.org/packages/Wolfgang.DbContextBuilder.AutoFixture) | AutoFixture-backed random data. Adds `.UseAutoFixture()` for `SeedWithRandom`. |
+| [`Wolfgang.DbContextBuilder.Bogus`](https://www.nuget.org/packages/Wolfgang.DbContextBuilder.Bogus) | Bogus-backed random data (realistic fake values). Adds `.UseBogus()`. |
+| [`Wolfgang.DbContextBuilder.Abstractions`](https://www.nuget.org/packages/Wolfgang.DbContextBuilder.Abstractions) | Shared `ICreateRandomEntities` abstraction, EF-Core-version-independent. Referenced transitively by the provider packages. |
+
 ```bash
-# Pick whichever matches your project's EF version
+# Pick whichever matches your project's EF version, plus a random-data provider
 dotnet add package Wolfgang.DbContextBuilder-Core-EF8
+dotnet add package Wolfgang.DbContextBuilder.AutoFixture   # or .Bogus
 ```
 
 ### Target frameworks
@@ -44,6 +53,9 @@ Each package targets the .NET runtimes its EF version requires:
 | `Wolfgang.DbContextBuilder-Core-EF9` | `net9.0` |
 | `Wolfgang.DbContextBuilder-Core-EF10` | `net10.0` |
 | `Wolfgang.DbContextBuilder-EF6` (classic) | `net462; net47; net471; net472; net48; net481` |
+| `Wolfgang.DbContextBuilder.Abstractions` | `netstandard2.0; net10.0` |
+| `Wolfgang.DbContextBuilder.AutoFixture` | `net6.0; net7.0; net8.0; net9.0; net10.0` |
+| `Wolfgang.DbContextBuilder.Bogus` | `net6.0; net7.0; net8.0; net9.0; net10.0` |
 
 ---
 
@@ -69,7 +81,7 @@ This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) f
 
 - **Seed with your own data** using `.SeedWith<T>(...)` — accepts an `IEnumerable<T>` or a `params T[]`.
 
-- **Seed with random data** using `.SeedWithRandom<T>(count)` to simulate real-world databases where additional rows beyond your test fixtures exist. Plug in a custom `ICreateRandomEntities` to control how the random rows are generated.
+- **Seed with random data** using `.SeedWithRandom<T>(count)` to simulate real-world databases where additional rows beyond your test fixtures exist. Choose a random-data provider — `.UseAutoFixture()` (the `Wolfgang.DbContextBuilder.AutoFixture` package) or `.UseBogus()` (`Wolfgang.DbContextBuilder.Bogus`) — or plug in your own `ICreateRandomEntities` via `.UseCustomRandomEntityCreator(...)`.
 
 - **Composable.** Chain `SeedWith`, `SeedWithRandom`, and provider options in any order, then call `.BuildAsync()` to materialize the `DbContext`.
 
@@ -80,6 +92,9 @@ This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) f
 ```csharp
 // Create a DbContext with seeded random data and your test data
 var context = await new DbContextBuilder<YourDbContext>()
+    // Pick a random-data provider (or .UseBogus()) so SeedWithRandom has a generator
+    .UseAutoFixture()
+
     // Seed with 10 random entities
     .SeedWithRandom<YourEntity>(10)
 
@@ -115,11 +130,14 @@ The Core package exposes a small, focused surface. The full reference is on the 
 | `.UseInMemory()` | EF Core InMemory provider. Fastest, ignores relational constraints. |
 | `.UseSqlite()` | SQLite in-memory provider. Enforces relational constraints. |
 | `.UseSqliteForMsSqlServer()` | SQLite in-memory with a SQL-Server compatibility layer that flattens schema-qualified table names and rewrites SQL-Server-specific default-value SQL. |
-| `.UseAutoFixture()` | Plug AutoFixture in as the random-entity generator (used by `SeedWithRandom`). |
-| `.UseDbContextOptionsBuilder(opts)` | Bring your own `DbContextOptionsBuilder<T>` to override the provider entirely. |
+| `.UseAutoFixture()` | Plug AutoFixture in as the random-entity generator (used by `SeedWithRandom`). Requires the `Wolfgang.DbContextBuilder.AutoFixture` package. |
+| `.UseBogus()` | Plug Bogus in as the random-entity generator (realistic fake values). Requires the `Wolfgang.DbContextBuilder.Bogus` package. |
 | `.UseCustomRandomEntityCreator(creator)` | Plug in any `ICreateRandomEntities` implementation. |
+| `.UseDbContextOptionsBuilder(opts)` | Bring your own `DbContextOptionsBuilder<T>` to override the provider entirely. |
+| `.UseSeedProfile(profile)` | Apply a reusable `ISeedProfile<T>` — a named bundle of seed data shareable across tests. Multiple profiles accumulate. |
+| `.UseDiagnosticOutput(writeLine)` | Route EF Core logs (and a one-line seed summary) to a sink such as `testOutputHelper.WriteLine`. |
 | `.SeedWith<TEntity>(...)` | Seed specific rows. Accepts `IEnumerable<T>` or `params T[]`. |
-| `.SeedWithRandom<TEntity>(count, [func])` | Seed N random rows. Optional `func` mutates each generated entity. |
+| `.SeedWithRandom<TEntity>(count, [func])` | Seed N random rows (requires a random-data provider). Optional `func` mutates each generated entity. |
 | `.BuildAsync()` | Materialize the `DbContext`. The builder owns the underlying connection; dispose the context with `await using`. |
 | `SqliteModelCustomizer` | Customization hooks for the SQLite-for-SQL-Server mode: `OverrideTableRenaming`, `OverrideDefaultValueHandling`, `OverrideComputedValueHandling`, `OverrideManyToManyTableHandling`, `DefaultValueMap`. |
 | `ICreateDbContext` / `ICreateRandomEntities` | Extension points for plugging in your own provider or random-entity generator. |


### PR DESCRIPTION
Documentation findings (Phase 6) from the full code-review pass — refreshing docs for the 0.8.0 package family.

## README.md
- **Installation** + **Target Frameworks** tables: added the three new 0.8.0 packages — `.Abstractions`, `.AutoFixture`, `.Bogus`.
- **API surface** table: added `.UseBogus()`, `.UseSeedProfile()`, `.UseDiagnosticOutput()`; annotated `.UseAutoFixture()`/`.UseBogus()` as requiring their packages.
- **Usage quick-start (must-fix):** it chained `.SeedWithRandom<T>(10)` with **no provider**, which throws `InvalidOperationException` under 0.8.0. Now calls `.UseAutoFixture()` first; the random-data feature bullet points at the provider packages.

## .github/copilot-instructions.md
Was describing the old single-package ".NET 8.0 / Wolfgang.DbContextBuilder" layout ("always reference these instructions first"). Updated: repo summary → the 10-package family, SDK prereq → .NET 10, coverage gate → the actual per-module 90%.

## Verified, no change
- **CONTRIBUTING "7 Analyzers"** — actually lists all seven (NetAnalyzers is item #1); the review's "lists only 6" was a miscount.
- **Committed `.user` files** — `git ls-files` confirms none are tracked (gitignored); false positive.

## Deferred (cannot action here)
The **examples project** (`examples/…Example03`, on published `0.7.0`, `SeedWithRandom` without a provider) will break once bumped to 0.8.0 — it needs the `.AutoFixture` package + `.UseAutoFixture()`. That package isn't on NuGet until 0.8.0 publishes, so the examples bump belongs to the **0.8.0 release step**, not this PR.

Independent of #353 / #354; mergeable in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
