### PR TITLE
fix(benchmarks): configure AutoFixture so InMemory_SeedWithRandom no longer throws

### DIFF
--- a/benchmarks/DbContextBuilder.Benchmarks/BuildAsyncBenchmarks.cs
+++ b/benchmarks/DbContextBuilder.Benchmarks/BuildAsyncBenchmarks.cs
@@ -89,6 +89,7 @@ public class BuildAsyncBenchmarks
     public async Task InMemory_SeedWithRandom()
     {
         using var builder = new DbContextBuilder<BenchmarkContext>()
+            .UseAutoFixture()
             .SeedWithRandom<BenchmarkEntity>(SeedCount);
         await using var context = await builder.BuildAsync().ConfigureAwait(false);
     }

--- a/benchmarks/DbContextBuilder.Benchmarks/DbContextBuilder.Benchmarks.csproj
+++ b/benchmarks/DbContextBuilder.Benchmarks/DbContextBuilder.Benchmarks.csproj
@@ -13,7 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Wolfgang.DbContextBuilder-Core\Wolfgang.DbContextBuilder-Core.csproj" />
+    <!-- The AutoFixture provider (net10.0 build) brings in Core-EF10 transitively, giving the
+         benchmark DbContextBuilder<T>, UseInMemory(), and UseAutoFixture() from a single matched
+         Core assembly. SeedWithRandom needs a configured provider since the EF Core packages no
+         longer bundle one. -->
+    <ProjectReference Include="..\..\src\Wolfgang.DbContextBuilder.AutoFixture\Wolfgang.DbContextBuilder.AutoFixture.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Found during a deep code-review pass (the first review scoped src/tests/docs/workflows but not `benchmarks/`).

## The bug
`benchmarks/…/BuildAsyncBenchmarks.cs` `InMemory_SeedWithRandom` called `SeedWithRandom<BenchmarkEntity>(SeedCount)` with **no random-data provider**. The benchmark `ProjectReference`s Core, so it builds against the now-faker-agnostic source — meaning this benchmark **throws `InvalidOperationException` at runtime on `vNext` today** (unlike the examples, which lag via a published-package reference).

## The fix
- Replaced the base `Wolfgang.DbContextBuilder-Core` `ProjectReference` with the **`.AutoFixture`** package. Its `net10.0` build brings `Core-EF10` transitively, so `DbContextBuilder<T>` / `UseInMemory()` / `UseAutoFixture()` all resolve from **one** matched Core assembly — referencing both base Core *and* a `Core-EFx` would collide on `DbContextBuilder<T>` (`CS0433`).
  - Side effect: the benchmark now measures against **EF Core 10** rather than EF Core 6 — more representative of current consumers.
- Added `.UseAutoFixture()` to `InMemory_SeedWithRandom`, matching its documented intent ("captures the AutoFixture cost").

## Verification
`dotnet build -c Release` clean. The `UseAutoFixture()` + `SeedWithRandom` path is covered by `Wolfgang.DbContextBuilder.AutoFixture.Tests.Unit` (green across net6.0–net10.0), so runtime is sound.

Stacked review-findings PR off `vNext` (paired with a docs PR for the shadow-FK reconciliation note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
