### PR TITLE
docs: note FK reconciliation only covers CLR-property foreign keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - a **required** FK with no seeded principal is left as the random value (still fails on a
     constraint-enforcing provider — seed the principal).
 
+  Reconciliation applies only to foreign keys exposed as CLR properties; shadow foreign keys
+  (tracked by EF without a CLR property) are left untouched.
+
   **Behavior change to be aware of:** the foreign-key values on a randomly-seeded entity are
   no longer the raw random values the generator produced — a previously-random `SupplierId`
   may now be `null`, and a `CustomerId` may now match a seeded customer. Tests that asserted

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -91,6 +91,11 @@ time:
 - a **required** FK with no seeded principal of its type is left as the random value (so it
   would still fail on a constraint-enforcing provider — the fix is to seed the principal).
 
+Reconciliation only applies to foreign keys exposed as **CLR properties** on the entity. A
+*shadow* foreign key — one EF Core tracks without a corresponding property on your class — is
+left untouched, so if you rely on shadow FKs, give the entity an explicit FK property (or seed
+those rows with `SeedWith`) to keep constraint-enforcing providers happy.
+
 > **This may be a little unexpected, even though it's correct:** the foreign-key values on a
 > randomly-seeded entity are **not** the raw random values the generator produced. Entities you
 > add with `SeedWith` are never touched — their explicit FK values are preserved exactly.

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
@@ -426,6 +426,8 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
     /// principal type is present, the dependent's FK is set to that principal's key; otherwise
     /// an optional FK is set to <c>null</c>. Required FKs with no available principal are left
     /// untouched (best effort). Entities added via <c>SeedWith</c> are never modified.
+    /// Only foreign keys exposed as CLR properties are reconciled; shadow foreign keys (tracked
+    /// by EF without a CLR property) are left as-is, since there is no property to set.
     /// </summary>
     /// <param name="context">A context whose model is used to resolve the relationships.</param>
     private void ReconcileRandomForeignKeys(DbContext context)


### PR DESCRIPTION
Documentation finding from the deep code-review pass.

`SeedWithRandom`'s foreign-key reconciliation (added in #103) reads/writes FK values via `PropertyInfo`, so a **shadow** foreign key — one EF Core tracks without a corresponding CLR property — is silently left untouched (`PropertyInfo?.SetValue` no-ops when there's no property). The behavior is correct and best-effort by design, but the docs described reconciliation without the caveat. A consumer relying on shadow FKs could seed the principals and still hit a constraint violation with no hint why.

Documented the CLR-property-only limitation in:
- `docfx_project/docs/getting-started.md` — the "Random data and foreign keys" section
- `DbContextBuilder.ReconcileRandomForeignKeys` XML doc
- the `CHANGELOG.md` #103 entry

Docs only — **no behavior change**. Release build clean.

Stacked review-findings PR off `vNext` (paired with the benchmark fix, #357).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
