### PR TITLE
docs(readme): fix Release badge query so it renders live status

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Uses the `Builder` pattern to create Entity Framework Core and classic Entity Fr
 [![NuGet](https://img.shields.io/nuget/v/Wolfgang.DbContextBuilder-Core.svg?logo=nuget&label=NuGet)](https://www.nuget.org/packages/Wolfgang.DbContextBuilder-Core)
 [![NuGet downloads](https://img.shields.io/nuget/dt/Wolfgang.DbContextBuilder-Core.svg?logo=nuget&label=downloads)](https://www.nuget.org/packages/Wolfgang.DbContextBuilder-Core)
 [![PR build](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/DbContextBuilder/pr.yaml?event=pull_request_target&label=PR%20build&logo=github)](https://github.com/Chris-Wolfgang/DbContextBuilder/actions/workflows/pr.yaml)
-[![Release](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/DbContextBuilder/release.yaml?label=release&logo=github)](https://github.com/Chris-Wolfgang/DbContextBuilder/actions/workflows/release.yaml)
+[![Release](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/DbContextBuilder/release.yaml?event=release&label=release&logo=github)](https://github.com/Chris-Wolfgang/DbContextBuilder/actions/workflows/release.yaml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-Multi--Targeted-purple.svg)](https://dotnet.microsoft.com/)
 [![GitHub](https://img.shields.io/badge/GitHub-Repository-181717?logo=github)](https://github.com/Chris-Wolfgang/DbContextBuilder)


### PR DESCRIPTION
## Summary

The Release badge on `release.yaml` had no event/branch filter, so shields.io defaults to the "latest run on the default branch" — but `release.yaml` fires on `release: published`, and those runs have `head_branch` = the git tag name (`v0.8.0`, etc.), never `main`. shields.io then falls back and reports "failing" even though every actual release has been green.

Same class of fix as the Category A pr.yaml badges. Adds `?event=release` so shields.io scopes to release-event runs regardless of branch.

One-character line diff. Docs-only.