### PR TITLE
chore(inspectcode): rename settings to match .slnx + suppress PublicAPI FPs (PR-1 of #377)

### DIFF
--- a/Wolfgang.DbContextBuilder.sln.DotSettings
+++ b/Wolfgang.DbContextBuilder.sln.DotSettings
@@ -1,2 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=xinfo/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Wolfgang.DbContextBuilder.slnx.DotSettings
+++ b/Wolfgang.DbContextBuilder.slnx.DotSettings
@@ -1,0 +1,46 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+  <!--
+    Team-shared InspectCode / ReSharper settings.
+
+    The pr.yaml `inspectcode` job runs `jb inspectcode Wolfgang.DbContextBuilder.slnx`
+    with no `--profile`, so it auto-loads the solution-shared settings file
+    named `<SolutionFileName>.DotSettings` — the extension IS part of the name.
+    Solution-wide overrides only; anything narrower belongs in a
+    `<ProjectName>.csproj.DotSettings`, a folder `.editorconfig`, or an
+    inline `#pragma` / `[SuppressMessage]` with justification.
+  -->
+
+  <!-- User dictionary carried over from the (now-renamed) .sln.DotSettings. -->
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=xinfo/@EntryIndexedValue">True</s:Boolean>
+
+  <!--
+    PublicApiAnalyzers false positives — RS0016 / RS0036 / RS0037.
+
+    Solution-wide is the correct scope here because the false positive is a
+    TOOL-WIDE bug in `jb inspectcode`, not a per-project issue: InspectCode
+    invokes Roslyn analyzers but does NOT pass the `PublicAPI.Shipped.txt` /
+    `PublicAPI.Unshipped.txt` files as `AdditionalFiles`. Without those,
+    PublicApiAnalyzer thinks NOTHING is declared and emits RS0016 ("add to
+    declared API"), RS0036 ("annotate nullability"), and RS0037 ("enable
+    nullability tracking") for every public member in every project that
+    has a PublicAPI.txt.
+
+    Verified 2026-08-13 against Chris-Wolfgang/DbContextBuilder main:
+
+      * `dotnet build src/Wolfgang.DbContextBuilder-Core/*.csproj -c Release
+         -p:TreatWarningsAsErrors=true` → Build succeeded (zero RS0016/37/36).
+      * `gh api .../code-scanning/alerts?tool_name=InspectCode` → 498 open
+         RS0016/RS0037/RS0036 alerts (366 + 92 + 40).
+
+    The in-build analyzer stack still enforces these correctly — this
+    suppression only silences the InspectCode duplicate SARIF upload.
+
+    Same root cause and same fix as Chris-Wolfgang/ETL-Xml (2026-08-12,
+    ~424 identical FPs cleared). Fleet reference:
+    `reference_inspectcode_publicapi_false_positives`.
+  -->
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RS0016/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RS0036/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RS0037/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+
+</wpf:ResourceDictionary>


### PR DESCRIPTION
## Summary

First PR of the per-bucket rework for #377 (fleet audit found 2,999 open InspectCode alerts on main — largest in the fleet). See the closed #378 for why the original solution-wide-suppression approach was scrapped: solution-wide DO_NOT_SHOW hides genuine hits in code where the rule DOES apply.

This PR does the two things where solution-wide scope IS correct:

### 1. Rename \`Wolfgang.DbContextBuilder.sln.DotSettings\` → \`.slnx.DotSettings\`

The pr.yaml \`inspectcode\` job runs \`jb inspectcode Wolfgang.DbContextBuilder.slnx\`, which auto-loads the solution-shared settings file named \`<SolutionFileName>.DotSettings\` — the extension IS part of the name. The \`.sln.DotSettings\` name never matched a real solution, so nothing in it was ever applied. That's the root cause of why no InspectCode noise floor existed on this repo — the file was there, just never loaded.

### 2. Suppress \`RS0016\` / \`RS0036\` / \`RS0037\` (498 alerts)

Tool-wide bug in \`jb inspectcode\`: it runs the Roslyn analyzer stack but does NOT pass \`PublicAPI.Shipped.txt\` / \`PublicAPI.Unshipped.txt\` as \`AdditionalFiles\`. Without those, PublicApiAnalyzer thinks nothing is declared and emits the diagnostics for every public member in every project that has a PublicAPI.txt.

**Solution-wide is the narrowest scope that covers this FP** — the tool bug applies to every project with a PublicAPI.txt (10 src projects in this repo), and the in-build analyzer stack still enforces the rule correctly locally.

**Verified against main (2026-08-13):**
- \`dotnet build src/Wolfgang.DbContextBuilder-Core/*.csproj -c Release -p:TreatWarningsAsErrors=true\` → **Build succeeded** (zero RS0016/37/36 firing locally).
- \`gh api .../code-scanning/alerts?tool_name=InspectCode\` → **498 open** RS0016/37/36 alerts.

Same root cause + fix as [ETL-Xml (2026-08-12)](https://github.com/Chris-Wolfgang/ETL-Xml) which cleared ~424 identical FPs.

## Expected effect

- **Before**: 2,999 open InspectCode alerts on main
- **After merge**: ~2,501 remain
- Remaining buckets (each in its own PR to keep review scope narrow):
  - **PR-2**: Per-project \`.csproj.DotSettings\` on 5 \`AdventureWorks-EF*\` projects for the R# rules that fire on EF-scaffolded \`Models/Generated/\` code (~2,377 alerts: \`CheckNamespace\`, \`PartialTypeWithSinglePart\`, \`PartialMethodWithSinglePart\`, \`RedundantUsingDirective\`, \`UnusedAutoPropertyAccessor.Global\`) + folder \`.editorconfig\` for \`CS8632\` (~354).
  - **PR-3**: Per-file \`#pragma warning disable EF1001\` with justification comments in the 3 files that intentionally use EF Core internals (~74 alerts).
  - **PR-4**: Real triage of the remaining ~50 findings (\`S1481\`, \`S3459\`, \`S2325\`, \`S4487\`, \`S4144\`, \`S3878\`, \`S2971\`, \`S2376\`, \`S101\`, \`MA0202\`, unused locals, etc.) — fix in code or narrow \`[SuppressMessage]\` with justification.

Final target from #377: alert count below 25.

## Test plan

- [ ] \`ReSharper InspectCode\` PR check runs with the newly-loaded profile
- [ ] After merge, alert count drops by ~498 (\`gh api .../code-scanning/alerts?state=open&tool_name=InspectCode --jq 'length'\`)
- [ ] No regression in Stage 1 / 2 / 3

## References

- #377 (umbrella)
- #378 (closed — original scope-too-wide attempt with rework rationale)
- Fleet memory \`reference_inspectcode_publicapi_false_positives\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)