### PR TITLE
chore(inspectcode): narrow suppressions for EF-scaffolded generated code (PR-2 of #377)

### DIFF
--- a/extra-projects/.editorconfig
+++ b/extra-projects/.editorconfig
@@ -24,3 +24,14 @@ dotnet_diagnostic.CA2007.severity = none
 # re-scaffolding always reintroduces MA0003/MA0051/CA1062 etc.
 [**/Models/Generated/*.cs]
 generated_code = true
+
+# CS8632 — "annotation for nullable reference types should only be used
+# in code within a '#nullable' annotations context." The scaffolder emits
+# `string?` / `T?` in these files but does NOT emit a `#nullable enable`
+# header. The repo-wide `<Nullable>enable</Nullable>` in Directory.Build.props
+# means the C# compiler sees them as valid (no CS8632 locally), but
+# `jb inspectcode` evaluates the analyzer without picking up the DBP
+# nullable context and flags every `?` (354 alerts across the 5
+# AdventureWorks-EF* projects). Suppress only inside Models/Generated/
+# so a real CS8632 in hand-written code still surfaces.
+dotnet_diagnostic.CS8632.severity = none

--- a/extra-projects/AdventureWorks-EF10/AdventureWorks-EF10.csproj.DotSettings
+++ b/extra-projects/AdventureWorks-EF10/AdventureWorks-EF10.csproj.DotSettings
@@ -1,0 +1,40 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+  <!--
+    Team-shared InspectCode / ReSharper settings for this AdventureWorks-EF*
+    demo project. Scope is per-project (not solution-wide) because these
+    findings are false positives ONLY on the EF Core scaffolder output in
+    Models/Generated/*.cs — hand-written code in src/ still gets the rules
+    enforced normally.
+
+    All ~90 .cs files under Models/Generated/ are produced by
+    `dotnet ef dbcontext scaffold`. They cannot be edited: the scaffolder
+    overwrites them on every regen. The specific noise:
+
+      * `CheckNamespace` — scaffolder emits `namespace AdventureWorks.Models`
+        for files that live under `Models/Generated/`.
+      * `PartialTypeWithSinglePart` — scaffolder emits `public partial record`
+        for every entity, one part per file.
+      * `PartialMethodWithSinglePart` — same pattern for scaffolder-emitted
+        partial methods.
+      * `RedundantUsingDirective` — scaffolder emits `using System;` etc. on
+        every file even though `<ImplicitUsings>enable</ImplicitUsings>`
+        provides them.
+      * `UnusedAutoPropertyAccessor.Global` — entity POCOs are data models
+        never instantiated in this demo (the project's `Program.cs` doesn't
+        exercise them), and R# can't see the InspectCode analyses per-project
+        so it treats every public property setter as unused.
+
+    The extra-projects/.editorconfig already marks Models/Generated/*.cs as
+    `generated_code = true`; Roslyn-based analyzers (Meziantou, CA, Sonar)
+    honour that marker but InspectCode's R#-native inspections do not.
+
+    Program.cs at the project root is a trivial demo shim (~1 file) and does
+    not exercise these rules in practice, so per-project scope is effectively
+    equivalent to Models/Generated/ scope for these projects.
+  -->
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CheckNamespace/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialTypeWithSinglePart/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialMethodWithSinglePart/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantUsingDirective/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedAutoPropertyAccessor_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+</wpf:ResourceDictionary>

--- a/extra-projects/AdventureWorks-EF6/AdventureWorks-EF6.csproj.DotSettings
+++ b/extra-projects/AdventureWorks-EF6/AdventureWorks-EF6.csproj.DotSettings
@@ -1,0 +1,40 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+  <!--
+    Team-shared InspectCode / ReSharper settings for this AdventureWorks-EF*
+    demo project. Scope is per-project (not solution-wide) because these
+    findings are false positives ONLY on the EF Core scaffolder output in
+    Models/Generated/*.cs — hand-written code in src/ still gets the rules
+    enforced normally.
+
+    All ~90 .cs files under Models/Generated/ are produced by
+    `dotnet ef dbcontext scaffold`. They cannot be edited: the scaffolder
+    overwrites them on every regen. The specific noise:
+
+      * `CheckNamespace` — scaffolder emits `namespace AdventureWorks.Models`
+        for files that live under `Models/Generated/`.
+      * `PartialTypeWithSinglePart` — scaffolder emits `public partial record`
+        for every entity, one part per file.
+      * `PartialMethodWithSinglePart` — same pattern for scaffolder-emitted
+        partial methods.
+      * `RedundantUsingDirective` — scaffolder emits `using System;` etc. on
+        every file even though `<ImplicitUsings>enable</ImplicitUsings>`
+        provides them.
+      * `UnusedAutoPropertyAccessor.Global` — entity POCOs are data models
+        never instantiated in this demo (the project's `Program.cs` doesn't
+        exercise them), and R# can't see the InspectCode analyses per-project
+        so it treats every public property setter as unused.
+
+    The extra-projects/.editorconfig already marks Models/Generated/*.cs as
+    `generated_code = true`; Roslyn-based analyzers (Meziantou, CA, Sonar)
+    honour that marker but InspectCode's R#-native inspections do not.
+
+    Program.cs at the project root is a trivial demo shim (~1 file) and does
+    not exercise these rules in practice, so per-project scope is effectively
+    equivalent to Models/Generated/ scope for these projects.
+  -->
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CheckNamespace/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialTypeWithSinglePart/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialMethodWithSinglePart/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantUsingDirective/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedAutoPropertyAccessor_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+</wpf:ResourceDictionary>

--- a/extra-projects/AdventureWorks-EF7/AdventureWorks-EF7.csproj.DotSettings
+++ b/extra-projects/AdventureWorks-EF7/AdventureWorks-EF7.csproj.DotSettings
@@ -1,0 +1,40 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+  <!--
+    Team-shared InspectCode / ReSharper settings for this AdventureWorks-EF*
+    demo project. Scope is per-project (not solution-wide) because these
+    findings are false positives ONLY on the EF Core scaffolder output in
+    Models/Generated/*.cs — hand-written code in src/ still gets the rules
+    enforced normally.
+
+    All ~90 .cs files under Models/Generated/ are produced by
+    `dotnet ef dbcontext scaffold`. They cannot be edited: the scaffolder
+    overwrites them on every regen. The specific noise:
+
+      * `CheckNamespace` — scaffolder emits `namespace AdventureWorks.Models`
+        for files that live under `Models/Generated/`.
+      * `PartialTypeWithSinglePart` — scaffolder emits `public partial record`
+        for every entity, one part per file.
+      * `PartialMethodWithSinglePart` — same pattern for scaffolder-emitted
+        partial methods.
+      * `RedundantUsingDirective` — scaffolder emits `using System;` etc. on
+        every file even though `<ImplicitUsings>enable</ImplicitUsings>`
+        provides them.
+      * `UnusedAutoPropertyAccessor.Global` — entity POCOs are data models
+        never instantiated in this demo (the project's `Program.cs` doesn't
+        exercise them), and R# can't see the InspectCode analyses per-project
+        so it treats every public property setter as unused.
+
+    The extra-projects/.editorconfig already marks Models/Generated/*.cs as
+    `generated_code = true`; Roslyn-based analyzers (Meziantou, CA, Sonar)
+    honour that marker but InspectCode's R#-native inspections do not.
+
+    Program.cs at the project root is a trivial demo shim (~1 file) and does
+    not exercise these rules in practice, so per-project scope is effectively
+    equivalent to Models/Generated/ scope for these projects.
+  -->
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CheckNamespace/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialTypeWithSinglePart/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialMethodWithSinglePart/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantUsingDirective/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedAutoPropertyAccessor_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+</wpf:ResourceDictionary>

--- a/extra-projects/AdventureWorks-EF8/AdventureWorks-EF8.csproj.DotSettings
+++ b/extra-projects/AdventureWorks-EF8/AdventureWorks-EF8.csproj.DotSettings
@@ -1,0 +1,40 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+  <!--
+    Team-shared InspectCode / ReSharper settings for this AdventureWorks-EF*
+    demo project. Scope is per-project (not solution-wide) because these
+    findings are false positives ONLY on the EF Core scaffolder output in
+    Models/Generated/*.cs — hand-written code in src/ still gets the rules
+    enforced normally.
+
+    All ~90 .cs files under Models/Generated/ are produced by
+    `dotnet ef dbcontext scaffold`. They cannot be edited: the scaffolder
+    overwrites them on every regen. The specific noise:
+
+      * `CheckNamespace` — scaffolder emits `namespace AdventureWorks.Models`
+        for files that live under `Models/Generated/`.
+      * `PartialTypeWithSinglePart` — scaffolder emits `public partial record`
+        for every entity, one part per file.
+      * `PartialMethodWithSinglePart` — same pattern for scaffolder-emitted
+        partial methods.
+      * `RedundantUsingDirective` — scaffolder emits `using System;` etc. on
+        every file even though `<ImplicitUsings>enable</ImplicitUsings>`
+        provides them.
+      * `UnusedAutoPropertyAccessor.Global` — entity POCOs are data models
+        never instantiated in this demo (the project's `Program.cs` doesn't
+        exercise them), and R# can't see the InspectCode analyses per-project
+        so it treats every public property setter as unused.
+
+    The extra-projects/.editorconfig already marks Models/Generated/*.cs as
+    `generated_code = true`; Roslyn-based analyzers (Meziantou, CA, Sonar)
+    honour that marker but InspectCode's R#-native inspections do not.
+
+    Program.cs at the project root is a trivial demo shim (~1 file) and does
+    not exercise these rules in practice, so per-project scope is effectively
+    equivalent to Models/Generated/ scope for these projects.
+  -->
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CheckNamespace/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialTypeWithSinglePart/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialMethodWithSinglePart/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantUsingDirective/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedAutoPropertyAccessor_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+</wpf:ResourceDictionary>

--- a/extra-projects/AdventureWorks-EF9/AdventureWorks-EF9.csproj.DotSettings
+++ b/extra-projects/AdventureWorks-EF9/AdventureWorks-EF9.csproj.DotSettings
@@ -1,0 +1,40 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+  <!--
+    Team-shared InspectCode / ReSharper settings for this AdventureWorks-EF*
+    demo project. Scope is per-project (not solution-wide) because these
+    findings are false positives ONLY on the EF Core scaffolder output in
+    Models/Generated/*.cs — hand-written code in src/ still gets the rules
+    enforced normally.
+
+    All ~90 .cs files under Models/Generated/ are produced by
+    `dotnet ef dbcontext scaffold`. They cannot be edited: the scaffolder
+    overwrites them on every regen. The specific noise:
+
+      * `CheckNamespace` — scaffolder emits `namespace AdventureWorks.Models`
+        for files that live under `Models/Generated/`.
+      * `PartialTypeWithSinglePart` — scaffolder emits `public partial record`
+        for every entity, one part per file.
+      * `PartialMethodWithSinglePart` — same pattern for scaffolder-emitted
+        partial methods.
+      * `RedundantUsingDirective` — scaffolder emits `using System;` etc. on
+        every file even though `<ImplicitUsings>enable</ImplicitUsings>`
+        provides them.
+      * `UnusedAutoPropertyAccessor.Global` — entity POCOs are data models
+        never instantiated in this demo (the project's `Program.cs` doesn't
+        exercise them), and R# can't see the InspectCode analyses per-project
+        so it treats every public property setter as unused.
+
+    The extra-projects/.editorconfig already marks Models/Generated/*.cs as
+    `generated_code = true`; Roslyn-based analyzers (Meziantou, CA, Sonar)
+    honour that marker but InspectCode's R#-native inspections do not.
+
+    Program.cs at the project root is a trivial demo shim (~1 file) and does
+    not exercise these rules in practice, so per-project scope is effectively
+    equivalent to Models/Generated/ scope for these projects.
+  -->
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CheckNamespace/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialTypeWithSinglePart/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialMethodWithSinglePart/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantUsingDirective/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+  <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedAutoPropertyAccessor_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+</wpf:ResourceDictionary>


### PR DESCRIPTION
## Summary

PR-2 of the per-bucket #377 rework. **Stacked on top of #379 (PR-1)** — merge PR-1 first.

Targets the ~2,382-alert bucket that dominates the count on \`main\`: false positives from the EF Core scaffolder output under \`extra-projects/AdventureWorks-EF*/Models/Generated/\`.

## Findings addressed

All ~90 \`.cs\` files per project under \`Models/Generated/\` are produced by \`dotnet ef dbcontext scaffold\` and cannot be edited (regen overwrites them). They emit:

| Rule | Alert count | Location |
|---|--:|---|
| \`CheckNamespace\` | 454 | all Models/Generated |
| \`RedundantUsingDirective\` | 540 (of 541) | all Models/Generated |
| \`UnusedAutoPropertyAccessor.Global\` | 584 (of 592) | all Models/Generated |
| \`PartialTypeWithSinglePart\` | 445 | all Models/Generated |
| \`PartialMethodWithSinglePart\` | 5 | all Models/Generated |
| \`CSharpWarnings::CS8632\` | 354 | all Models/Generated |

\`extra-projects/.editorconfig\` already marks these as \`generated_code = true\`, which Roslyn analyzers honor — but InspectCode's R#-native inspections do not.

## Two narrow scopes (not solution-wide DO_NOT_SHOW)

### 1. \`extra-projects/.editorconfig\` — CS8632 for generated files only

Added \`dotnet_diagnostic.CS8632.severity = none\` inside the existing \`[**/Models/Generated/*.cs]\` block. CS8632 is a compiler diagnostic (respected by .editorconfig), so this scopes suppression to exactly the generated files. Hand-written code in src/ still gets CS8632 enforced.

### 2. Five \`AdventureWorks-EF{N}.csproj.DotSettings\` files

One per demo project (EF6, EF7, EF8, EF9, EF10) — each suppresses the R#-native inspections that fire on scaffolder output. Per-project scope is effectively equivalent to Models/Generated/ scope for these projects: each has ~90 generated files and a trivial \`Program.cs\`. The main solution's src/, tests/, benchmarks/, and examples/ projects are unaffected — a real \`CheckNamespace\` or \`PartialTypeWithSinglePart\` in hand-written code still surfaces.

## Expected effect

- After PR-1 lands: ~2,501 alerts remain
- After this PR: **~119 remaining**
- PR-3 (EF1001 per-file pragma): ~45 remaining
- PR-4 (real triage of Sonar/MA/local-unused): under 25 (target from #377)

## Test plan

- [ ] \`ReSharper InspectCode\` PR check runs cleanly
- [ ] After stack merges, verify count via \`gh api .../code-scanning/alerts?state=open&tool_name=InspectCode --jq 'length'\`
- [ ] Confirm no regression in Stage 1 / 2 / 3

## References

- Stacked on #379 (PR-1)
- Umbrella #377
- #378 (closed — original scope-too-wide attempt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)