### PR TITLE
chore(inspectcode): narrow EF1001 pragmas at intentional-internals sites (PR-3 of #377)

### DIFF
--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderSqliteExtensions.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilderSqliteExtensions.cs
@@ -80,7 +80,13 @@ public static class DbContextBuilderSqliteExtensions
         // Avoid registering EF services multiple times. Use a typeof check on the
         // SQLite options extension type rather than matching its FullName as a string
         // (which silently breaks if EF renames or moves the type).
+        //
+        // SqliteOptionsExtension lives in EF Core's internal namespace
+        // (Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal) — the typeof
+        // check on it is deliberate for the reason above, so EF1001 is expected here.
+#pragma warning disable EF1001 // Internal EF Core API usage
         if (!builder.ServiceCollection.Any(sd => sd.ServiceType == typeof(SqliteOptionsExtension)))
+#pragma warning restore EF1001
         {
             builder.ServiceCollection.AddEntityFrameworkSqlite();
         }

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteForMsSqlServerModelCustomizerTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteForMsSqlServerModelCustomizerTests.cs
@@ -1,6 +1,15 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Moq;
 
+// SqliteForMsSqlServerModelCustomizer is a wrapper over EF Core's ModelCustomizer,
+// and its public surface takes ModelCustomizerDependencies — an EF-internal type
+// (Microsoft.EntityFrameworkCore.Infrastructure). Every test in this file
+// constructs that dependency or exercises the customizer via its EF-internal
+// callers, which is EF1001 by design — the type under test IS the wrapper over
+// the internal API. Suppressing the diagnostic at the file level rather than
+// adding 21 separate [SuppressMessage] attributes or per-line pragmas.
+#pragma warning disable EF1001 // Internal EF Core API usage — see file-level rationale above
+
 namespace Wolfgang.DbContextBuilderCore.Tests.Unit;
 
 /// <summary>

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteModelCustomizerTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteModelCustomizerTests.cs
@@ -4,6 +4,16 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Moq;
 using Wolfgang.DbContextBuilderCore.Tests.Unit.Models;
 
+// SqliteModelCustomizer is a wrapper over EF Core's ModelCustomizer, and its
+// public surface takes ModelCustomizerDependencies — an EF-internal type
+// (Microsoft.EntityFrameworkCore.Infrastructure). Every test in this file
+// constructs that dependency or exercises the customizer via its EF-internal
+// callers (IDbSetFinder, IModelRuntimeInitializer, etc.), which is EF1001 by
+// design — the type under test IS the wrapper over the internal API.
+// Suppressing the diagnostic at the file level rather than adding 52 separate
+// [SuppressMessage] attributes or per-line pragmas across every test method.
+#pragma warning disable EF1001 // Internal EF Core API usage — see file-level rationale above
+
 namespace Wolfgang.DbContextBuilderCore.Tests.Unit;
 
 /// <summary>


### PR DESCRIPTION
## Summary

PR-3 of the per-bucket #377 rework. **Stacked on #380 (PR-2)** — merge PR-1 → PR-2 → this in order.

EF1001 fires on intentional consumption of EF Core internal APIs. This library *is* a DbContext-builder that wraps EF's \`ModelCustomizer\` / service-collection wiring, so touching internals is the library's whole purpose — but the diagnostic is correct for hand-written product code that isn't in the wrapper layer. Suppress narrowly at each intentional site, not globally.

## The 74 EF1001 alerts by location

| File | Alert count | Scope of fix |
|---|--:|---|
| \`src/Wolfgang.DbContextBuilder-Core/DbContextBuilderSqliteExtensions.cs\` | 1 (line 83) | Per-expression \`#pragma\` around the single \`typeof(SqliteOptionsExtension)\` check |
| \`tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteModelCustomizerTests.cs\` | 52 (52 distinct lines) | File-level \`#pragma\` — every test constructs \`ModelCustomizerDependencies\` or exercises internal callers (\`IDbSetFinder\`, \`IModelRuntimeInitializer\`) because the *type under test IS* the wrapper over the internal API |
| \`tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteForMsSqlServerModelCustomizerTests.cs\` | 21 (21 distinct lines) | Same pattern, file-level \`#pragma\` |

Every other test in the suite (and any future test of hand-written product code) still gets EF1001 enforced by the in-build analyzer.

## Verified locally

- \`dotnet build src/Wolfgang.DbContextBuilder-Core/*.csproj -c Release -p:TreatWarningsAsErrors=true\` → **0 Errors**
- \`dotnet build tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/*.csproj -c Release\` → **0 Errors**

## Expected effect

- After PR-1 + PR-2 land: ~119 alerts remain
- After this PR: **~45 remaining**
- PR-4: real triage of residual Sonar/MA/local-unused findings to reach the #377 target of <25

## Test plan

- [ ] Stage 1 / 2 / 3 tests still pass (no accidental behavior change from the pragma placement)
- [ ] \`ReSharper InspectCode\` PR check no longer reports EF1001 in these files
- [ ] After stack merges, verify alert count via \`gh api\`

## References

- Stacked on #380 (PR-2), which is stacked on #379 (PR-1)
- Umbrella #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)