### PR TITLE
chore(inspectcode): triage residual 41 alerts — real fixes + narrow suppressions (PR-4 of #377)

### DIFF
--- a/benchmarks/DbContextBuilder.Benchmarks/BuildAsyncBenchmarks.cs
+++ b/benchmarks/DbContextBuilder.Benchmarks/BuildAsyncBenchmarks.cs
@@ -31,6 +31,10 @@ public class BuildAsyncBenchmarks
     /// chart shows the per-row component of build cost without dominating
     /// runtime.
     /// </summary>
+    // BenchmarkDotNet sets [Params]-annotated properties via reflection for
+    // each combination; R# cannot see reflection consumers so it reports the
+    // setter as unused.
+    // ReSharper disable once UnusedAutoPropertyAccessor.Global
     [Params(1, 10, 100)]
     public int SeedCount { get; set; }
 

--- a/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
+++ b/src/Wolfgang.DbContextBuilder-Core/DbContextBuilder.cs
@@ -512,15 +512,7 @@ public class DbContextBuilder<T> : IDisposable where T : DbContext
         }
 
         // Prefer a principal that is not the dependent itself (handles self-referencing FKs).
-        foreach (var candidate in candidates)
-        {
-            if (!ReferenceEquals(candidate, dependent))
-            {
-                return candidate;
-            }
-        }
-
-        return null;
+        return candidates.FirstOrDefault(candidate => !ReferenceEquals(candidate, dependent));
     }
 
 

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/Models/TableWithDefaults.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/Models/TableWithDefaults.cs
@@ -1,5 +1,9 @@
 ﻿namespace Wolfgang.DbContextBuilderCore.Tests.Unit.Models;
 
+// Test-only EF entity POCO — properties are populated by EF Core / the
+// DbContextBuilder seeding paths via reflection. R# cannot see external
+// reflection consumers so it reports the setters as never used.
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 internal class TableWithDefaults
 {
     public int Id { get; set; }

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedWithRandomCoverageTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SeedWithRandomCoverageTests.cs
@@ -364,6 +364,10 @@ internal sealed class CoverageSupplier
 
 
 
+// Test-only EF entity POCO — properties are populated by the random-entity
+// creator via reflection. R# cannot see reflection consumers and reports the
+// scalar FK setters as unused.
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 [ExcludeFromCodeCoverage(Justification = "Test model")]
 internal class CoverageWidget
 {

--- a/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteForMsSqlServerModelCustomizerTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/SqliteForMsSqlServerModelCustomizerTests.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
+#if EF_CORE_6
 using Moq;
+#endif
 
 // SqliteForMsSqlServerModelCustomizer is a wrapper over EF Core's ModelCustomizer,
 // and its public surface takes ModelCustomizerDependencies — an EF-internal type
@@ -28,15 +30,12 @@ public class SqliteForMsSqlServerModelCustomizerTests
 #if EF_CORE_6
         var finder = new Mock<IDbSetFinder>().Object;
         var dependencies = new ModelCustomizerDependencies(finder);
-#elif EF_CORE_7 || EF_CORE_8 
-        var dependencies = new ModelCustomizerDependencies();
 #else
         var dependencies = new ModelCustomizerDependencies();
 #endif
 
-        // Act & Assert
-        // ReSharper disable once UnusedVariable
-        var sut = new SqliteForMsSqlServerModelCustomizer(dependencies);
+        // Act & Assert — construction alone is the assertion (must not throw).
+        _ = new SqliteForMsSqlServerModelCustomizer(dependencies);
     }
 
 

--- a/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/DbContextBuilderTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/DbContextBuilderTests.cs
@@ -9,7 +9,7 @@ namespace Wolfgang.DbContextBuilderEF6.Tests.Unit;
 public class DbContextBuilderTests
 {
 
-    private DbContextBuilder<TestDbContext> CreateDbContextBuilder() =>
+    private static DbContextBuilder<TestDbContext> CreateDbContextBuilder() =>
         new DbContextBuilder<TestDbContext>()
             .UseEffort()
             .UseAutoFixture();

--- a/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/IgnoreVirtualMembersTests.cs
+++ b/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/IgnoreVirtualMembersTests.cs
@@ -142,10 +142,17 @@ public class IgnoreVirtualMembersTests
 
 /// <summary>
 /// Test class with a write-only property (no getter) for testing IgnoreVirtualMembers.
+/// The write-only shape and the backing-field-never-read are the WHOLE POINT of the
+/// test: we're verifying the customization's behaviour on this exact declaration
+/// pattern. Sonar S2376 / S4487 and R# NotAccessedField.Local would eliminate the
+/// pattern under test.
 /// </summary>
 [ExcludeFromCodeCoverage]
+[SuppressMessage("Minor Code Smell", "S2376:Write-only properties should not be used", Justification = "The write-only shape is the test fixture.")]
+[SuppressMessage("Minor Code Smell", "S4487:Unread \"private\" fields should be removed", Justification = "Backing field is deliberately unread; the write-only property is under test.")]
 internal class WriteOnlyPropertyClass
 {
+    // ReSharper disable once NotAccessedField.Local
     private string _writeOnly = string.Empty;
 
     public string WriteOnly

--- a/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/Models/Category.cs
+++ b/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/Models/Category.cs
@@ -4,6 +4,9 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Wolfgang.DbContextBuilderEF6.Tests.Unit.Models;
 
+// Test-only EF entity POCO — properties are populated by EF Core via reflection.
+// R# cannot see external reflection consumers so it reports the getter as unused.
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 [ExcludeFromCodeCoverage]
 [Table("Category")]
 public class Category

--- a/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/Models/Product.cs
+++ b/tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/Models/Product.cs
@@ -5,6 +5,9 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Wolfgang.DbContextBuilderEF6.Tests.Unit.Models;
 
+// Test-only EF entity POCO — properties are populated by EF Core via reflection.
+// R# cannot see external reflection consumers so it reports the getter as unused.
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 [ExcludeFromCodeCoverage]
 [Table("Product")]
 public class Product

--- a/tests/Wolfgang.DbContextBuilder.AutoFixture.Tests.Unit/DbContextBuilderTestsBase.cs
+++ b/tests/Wolfgang.DbContextBuilder.AutoFixture.Tests.Unit/DbContextBuilderTestsBase.cs
@@ -677,7 +677,9 @@ public abstract class DbContextBuilderTestsBase
         // paramName "entities". Assert at the Exception level so the test is resilient
         // to overload-resolution choices.
         Assert.Throws<ArgumentException>(() => sut.SeedWith("Invalid value"));
+#pragma warning disable S3878 // Explicit array literal is deliberate here — it forces overload resolution to the params/array overload instead of the singleton overload above.
         Assert.Throws<ArgumentException>(() => sut.SeedWith(new[] { "Invalid value" }));
+#pragma warning restore S3878
     }
 
 
@@ -733,7 +735,7 @@ public abstract class DbContextBuilderTestsBase
 
         var actualCountry = context
             .CountryRegions
-            .ToList()
+            .AsEnumerable()
             // Sqlite store the data time as unknown so we need to tell .net that it is UTC
             .Select(c => c with { ModifiedDate = DateTime.SpecifyKind(c.ModifiedDate, DateTimeKind.Utc) })
             .ToArray();
@@ -1047,45 +1049,6 @@ public abstract class DbContextBuilderTestsBase
 
 
     /// <summary>
-    /// Verifies that a newly created DbContext contains the specified number of randomly created entities.
-    /// </summary>
-    [Theory]
-    [InlineData(7)]
-    [InlineData(17)]
-    public async Task SeedWithRandom_int_func_TEntity_int_TEntity_seeds_DbContext_with_specified_values(int count)
-    {
-        const int startingId = 1001;
-        // Arrange
-        var sut = CreateDbContextBuilder();
-        var func = new Func<Person, int, Person>((a, i) =>
-        {
-            a.BusinessEntityId = startingId + i;
-            a.AdditionalContactInfo = null;
-            a.BusinessEntity = new BusinessEntity
-            {
-                BusinessEntityId = startingId + i
-            };
-            return a;
-        });
-
-        var context = await sut
-            .SeedWithRandom(count, func)
-            .BuildAsync();
-
-
-        // Act
-        var actualPeople = context
-            .People
-            .ToList();
-
-        // Assert
-        Assert.NotNull(actualPeople);
-        Assert.Equal(count, actualPeople.Count);
-    }
-
-
-
-    /// <summary>
     /// Verifies that calling UseDbContextOptionsBuilder and passing null throws ArgumentNullException
     /// </summary>
     [Fact]
@@ -1233,7 +1196,7 @@ public abstract class DbContextBuilderTestsBase
         // Assert
         var row = context.Addresses.SingleOrDefault(a => a.AddressId == 999);
         Assert.NotNull(row);
-        Assert.Equal("1 Singleton Way", row!.AddressLine1);
+        Assert.Equal("1 Singleton Way", row.AddressLine1);
     }
 
 

--- a/tests/Wolfgang.DbContextBuilder.AutoFixture.Tests.Unit/ICreateRandomEntitiesTestsBase.cs
+++ b/tests/Wolfgang.DbContextBuilder.AutoFixture.Tests.Unit/ICreateRandomEntitiesTestsBase.cs
@@ -1,10 +1,13 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Wolfgang.DbContextBuilderCore.Tests.Unit
 {
     /// <summary>
     /// Provides a base class for tests related to the ICreateRandomEntities interface.
     /// </summary>
     // ReSharper disable once InconsistentNaming
-    public abstract class ICreateRandomEntitiesTestsBase 
+    [SuppressMessage("Naming", "S101:Types should be named in PascalCase", Justification = "Deliberate: name mirrors the interface under test (ICreateRandomEntities).")]
+    public abstract class ICreateRandomEntitiesTestsBase
     {
 
         /// <summary>

--- a/tests/Wolfgang.DbContextBuilder.AutoFixture.Tests.Unit/IgnoreVirtualMembersCustomizationTests.cs
+++ b/tests/Wolfgang.DbContextBuilder.AutoFixture.Tests.Unit/IgnoreVirtualMembersCustomizationTests.cs
@@ -15,9 +15,8 @@ public class IgnoreVirtualMembersCustomizationTests
     {
         // Arrange
 
-        // Act
-        // ReSharper disable once UseDiscardAssignment
-        var unused = new IgnoreVirtualMembersCustomization();
+        // Act — construction alone is the assertion (must not throw).
+        _ = new IgnoreVirtualMembersCustomization();
     }
 
 
@@ -125,12 +124,20 @@ public class IgnoreVirtualMembersCustomizationTests
     }
 
 
+    // Test fixture — the customization under test populates VirtualProperty
+    // via reflection, and NonVirtualMethod exists to contrast against
+    // VirtualMethod (Sonar S2325's "make static" suggestion would defeat
+    // the contrast). All members are exercised by the test's inspection
+    // rather than direct call.
     // ReSharper disable once ClassNeverInstantiated.Local
+    // ReSharper disable UnusedAutoPropertyAccessor.Global
     private class TestClass
     {
         public virtual string? VirtualProperty { get; set; }
         public string NonVirtualProperty { get; set; } = "NonVirtual";
         public virtual int VirtualMethod() => 0;
+#pragma warning disable S2325 // Deliberately non-static: contrasts against VirtualMethod for the customization test
         public int NonVirtualMethod() => 42;
+#pragma warning restore S2325
     }
 }

--- a/tests/Wolfgang.DbContextBuilder.AutoFixture.Tests.Unit/NoCircularReferencesCustomizationTests.cs
+++ b/tests/Wolfgang.DbContextBuilder.AutoFixture.Tests.Unit/NoCircularReferencesCustomizationTests.cs
@@ -16,9 +16,9 @@ public class NoCircularReferencesCustomizationTests
     public void Can_create_instance_of_NoCircularReferencesCustomization()
     {
         // Arrange
-        
-        // Act
-        var unused = new AutoFixtureRandomEntityCreator.NoCircularReferencesCustomization();
+
+        // Act — construction alone is the assertion (must not throw).
+        _ = new AutoFixtureRandomEntityCreator.NoCircularReferencesCustomization();
     }
 
 

--- a/tests/Wolfgang.DbContextBuilder.AutoFixture.Tests.Unit/TestsWithSqliteAndAutoFixture.cs
+++ b/tests/Wolfgang.DbContextBuilder.AutoFixture.Tests.Unit/TestsWithSqliteAndAutoFixture.cs
@@ -468,7 +468,7 @@ public class TestsWithSqliteAndAutoFixture : DbContextBuilderTestsBase
 
         // Assert
         Assert.NotNull(roundTripped);
-        Assert.Equal(42, roundTripped!.BusinessEntityId);
+        Assert.Equal(42, roundTripped.BusinessEntityId);
         Assert.Equal(seedRowguid, roundTripped.Rowguid);
         Assert.Equal(seedModifiedDate, roundTripped.ModifiedDate);
     }
@@ -513,9 +513,9 @@ public class TestsWithSqliteAndAutoFixture : DbContextBuilderTestsBase
         };
 
         using var sut = CreateDbContextBuilder()
-            .SeedWith<BusinessEntity>(businessEntity)
-            .SeedWith<Currency>(currency)
-            .SeedWith<Culture>(culture);
+            .SeedWith(businessEntity)
+            .SeedWith(currency)
+            .SeedWith(culture);
 
         // Act
         await using var context = await sut.BuildAsync();

--- a/tests/Wolfgang.DbContextBuilder.Bogus.Tests.Unit/BogusRandomEntityCreatorTests.cs
+++ b/tests/Wolfgang.DbContextBuilder.Bogus.Tests.Unit/BogusRandomEntityCreatorTests.cs
@@ -5,8 +5,14 @@ namespace Wolfgang.DbContextBuilderCore.Tests.Unit;
 /// </summary>
 public class BogusRandomEntityCreatorTests
 {
-    // One property of every type BogusRandomEntityCreator has a rule for, so a single
-    // generation exercises every value generator.
+    // Every property on `Sample` is populated by `BogusRandomEntityCreator` via
+    // reflection — the class exists to give the creator a shape with one property
+    // per type-rule to exercise. R# and Sonar can only see the declaration and
+    // report them as unused / unassigned; the fixture pattern is deliberate.
+    // Suppressions kept on the fixture class only, not the surrounding tests.
+    // ReSharper disable UnusedMember.Local
+    // ReSharper disable UnusedAutoPropertyAccessor.Local
+#pragma warning disable S3459 // Unassigned auto-property — assigned via reflection by Bogus
     private sealed class Sample
     {
         public string Name { get; set; } = string.Empty;
@@ -33,6 +39,9 @@ public class BogusRandomEntityCreatorTests
 
         public DateTimeOffset UpdatedOn { get; set; }
     }
+#pragma warning restore S3459
+    // ReSharper restore UnusedAutoPropertyAccessor.Local
+    // ReSharper restore UnusedMember.Local
 
 
 


### PR DESCRIPTION
## Summary

Final PR of the per-bucket #377 rework. **Stacked on #381 (PR-3)** — merge PR-1 → PR-2 → PR-3 → this in order.

After PR-1/2/3 land, ~45 alerts remain. This PR takes them down toward zero by **fixing real issues in code** first, and applying **narrow-scope suppressions** only where the code is correct and the warning is genuinely wrong. Every suppression carries a justification.

## Real code fixes (removed noise via correct changes)

| Rule | Where | Change |
|---|---|---|
| \`S3267\` | \`src/.../DbContextBuilder.cs:515\` | \`foreach { if... return }\` → \`FirstOrDefault(...)\`; same behaviour, idiomatic LINQ |
| \`S2971\` | \`tests/.../DbContextBuilderTestsBase.cs:736\` | \`.ToList()\` immediately followed by \`.Select\` → \`.AsEnumerable()\`; drops the intermediate List allocation |
| \`S4144\` | \`tests/.../DbContextBuilderTestsBase.cs:1055\` | **Removed duplicate test** — \`_with_specified_values\` was byte-identical to \`_with_specified_number_of_random_entities\` right above it; zero coverage lost. See "Test change to review" below. |
| \`S2325\` | \`tests/Wolfgang.DbContextBuilder-EF6.Tests.Unit/DbContextBuilderTests.cs:12\` | \`CreateDbContextBuilder\` doesn't use \`this\` → \`static\` |
| \`S1481\` × 3 | 3 files | \`var sut = new ...\` / \`var unused = new ...\` (test's real assertion is "construction doesn't throw") → \`_ = new ...\` |
| \`RedundantSuppressNullableWarningExpression\` × 2 | 2 files | \`row!.X\` after \`Assert.NotNull(row)\` — \`!\` redundant with xUnit's NotNull annotation. Removed. |
| \`RedundantTypeArgumentsOfMethod\` × 3 | \`TestsWithSqliteAndAutoFixture.cs:516-518\` | \`.SeedWith<T>(x)\` → \`.SeedWith(x)\` (T inferable) |
| \`RedundantUsingDirective\` | \`SqliteForMsSqlServerModelCustomizerTests.cs:2\` | \`using Moq;\` only needed under \`#if EF_CORE_6\` — wrapped in the same \`#if\` |
| \`MA0202\` | \`SqliteForMsSqlServerModelCustomizerTests.cs:24\` | \`#elif EF_CORE_7 \|\| EF_CORE_8\` branch was identical to \`#else\` — collapsed |

## Narrow-scope suppressions (code correct, warning wrong)

Every suppression sits at the tightest scope that eliminates the FP.

- **Test-model POCOs populated via reflection** — file-level \`// ReSharper disable UnusedAutoPropertyAccessor.Global\` on 5 fixture files (\`Models/TableWithDefaults.cs\`, \`Models/Category.cs\`, \`Models/Product.cs\`, \`CoverageWidget\` in \`SeedWithRandomCoverageTests.cs\`, \`TestClass\` in \`IgnoreVirtualMembersCustomizationTests.cs\`). R# can't see reflection consumers.
- **\`Sample\` fixture in \`BogusRandomEntityCreatorTests.cs\`** — populated by Bogus via reflection; file-level \`// ReSharper disable\` for \`UnusedMember.Local\` + \`UnusedAutoPropertyAccessor.Local\` + \`#pragma warning disable S3459\`, scoped to the class only.
- **BDN \`[Params]\` in benchmarks** — set by BenchmarkDotNet via reflection; per-line \`// ReSharper disable once UnusedAutoPropertyAccessor.Global\`.
- **\`WriteOnlyPropertyClass\` in \`IgnoreVirtualMembersTests.cs\`** — the write-only shape + unread backing field ARE the test fixture. Per-class \`[SuppressMessage]\` for \`S2376\` / \`S4487\` with justification.
- **\`NonVirtualMethod\` in \`IgnoreVirtualMembersCustomizationTests.cs\`** — making it \`static\` would defeat the "virtual vs non-virtual" contrast the test relies on. Per-line \`#pragma warning disable S2325\` with justification.
- **\`sut.SeedWith(new[] { "Invalid value" })\`** — the explicit array literal FORCES overload resolution to the params/array overload. Per-line \`#pragma warning disable S3878\` with justification.
- **\`ICreateRandomEntitiesTestsBase\`** — deliberate name mirrors the interface under test. \`[SuppressMessage("Naming", "S101")]\` with justification.

## Test change to review

The \`S4144\` fix **deleted \`SeedWithRandom_int_func_TEntity_int_TEntity_seeds_DbContext_with_specified_values\`** because it was byte-identical to the method right above it (no unique assertions). The name suggests it was intended to also assert on the seeded field values (\`BusinessEntityId\`, etc.) but the assertions were never written. If a real "specified values" test is desired, please open a follow-up — the deletion here only removes a duplicate that added zero coverage.

## Verified locally

- \`dotnet build src/... -c Release -p:TreatWarningsAsErrors=true\` → 0 Errors
- \`dotnet test tests/Wolfgang.DbContextBuilder-Core.Tests.Unit\` → **86/86** pass on net6/7/8/9/10
- \`dotnet test tests/Wolfgang.DbContextBuilder.AutoFixture.Tests.Unit\` → **196/196** pass on all TFMs
- \`dotnet test tests/Wolfgang.DbContextBuilder.Bogus.Tests.Unit\` → **7/7** pass on all TFMs

## Expected effect (across the full stack)

| Stage | Alerts remaining |
|---|--:|
| Before PR-1 (main) | 2,999 |
| After PR-1 lands | ~2,501 |
| After PR-2 lands | ~119 |
| After PR-3 lands | ~45 |
| **After this PR lands** | **~0-5** (any drift / SARIF lag) |

Well under the #377 target of <25.

## References

- Stacked on #381 (PR-3), which is stacked on #380 (PR-2), which is stacked on #379 (PR-1)
- Umbrella #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)