### PR TITLE
build(analyzers): bump PublicApiAnalyzers 3.3.4 → 5.6.0 (protected-file bypass; closes ~496 InspectCode alerts)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -73,7 +73,7 @@
          Library projects under src/ should opt in; test / example /
          benchmark projects should not. Per-repo enablement is tracked as a
          follow-up maintenance issue. -->
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

Root-causes the residual **~496 open InspectCode alerts** on \`main\` (365 \`RS0016\` + 91 \`RS0037\` + 40 \`RS0036\`) that PR #379's solution-wide \`DO_NOT_SHOW\` was supposed to eliminate but didn't.

## The finding

PR #379 landed \`DO_NOT_SHOW\` for RS0016/36/37 in \`Wolfgang.DbContextBuilder.slnx.DotSettings\` on the theory that \`jb inspectcode\` runs PublicApiAnalyzer without forwarding \`PublicAPI.*.txt\` as \`AdditionalFiles\`. That pattern **works** on ETL-Xml (0 open alerts) but **not** here.

Comparing the two repos:

| Repo | `Microsoft.CodeAnalysis.PublicApiAnalyzers` | Open RS0016/36/37 on `main` |
|---|---|--:|
| ETL-Xml | **5.6.0** | 0 |
| DbContextBuilder | **3.3.4** (fleet baseline) | 496 |

PublicApiAnalyzer 3.3.4 spuriously emits RS0016/36/37 under InspectCode's Roslyn hosting even with a valid \`PublicAPI.*.txt\` present; 5.6.0 does not. Bumping to match the fleet-standard version.

The \`DO_NOT_SHOW\` entries in \`.slnx.DotSettings\` stay in place as a belt-and-suspenders guard.

## Why this is its own PR (bypass)

\`Directory.Build.props\` is protected — the pr.yaml "Detect .NET Projects" guard skips Stage 1/2/3 and InspectCode on any PR that touches it. Rather than admin-bypass the full release PR #384 (22 non-protected files), extract this single-file change to its own bypass PR. After merge, \`main\` merges back into \`vNext\` and #384 runs its full CI green.

## Verified locally

- \`dotnet build src/Wolfgang.DbContextBuilder-Core/*.csproj -c Release -p:TreatWarningsAsErrors=true\` → **0 Errors**
- No new analyzer diagnostics from 5.6.0 on this codebase.

## Merge flow

1. **This PR** admin-bypass merged to \`main\`.
2. \`main\` merged back into \`vNext\` (opens up #384's checks).
3. **#384** finishes its CI green.
4. Tag \`v0.8.1\` for the release.

## Expected effect

Next InspectCode analysis on \`main\` should drop from ~501 → ~5 (residual 4 UnusedParameter.Local + 1 UnusedAutoPropertyAccessor.Global from the earlier PR-4 slop). Well under the #377 target of <25.

## References

- #377 (umbrella)
- #384 (release PR on vNext — waiting on this)
- Fleet reference: \`reference_inspectcode_publicapi_false_positives\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)