### PR TITLE
chore(inspectcode): drop unused args from AdventureWorks Program.cs (triggers main SARIF refresh)

### DIFF
--- a/extra-projects/AdventureWorks-EF10/Program.cs
+++ b/extra-projects/AdventureWorks-EF10/Program.cs
@@ -3,7 +3,7 @@ namespace AdventureWorks_EF10
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     internal class Program
     {
-        static void Main(string[] args)
+        static void Main()
         {
             Console.WriteLine("Hello, World!");
         }

--- a/extra-projects/AdventureWorks-EF7/Program.cs
+++ b/extra-projects/AdventureWorks-EF7/Program.cs
@@ -3,7 +3,7 @@ namespace AdventureWorks_EF7
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     internal class Program
     {
-        static void Main(string[] args)
+        static void Main()
         {
             Console.WriteLine("Hello, World!");
         }

--- a/extra-projects/AdventureWorks-EF8/Program.cs
+++ b/extra-projects/AdventureWorks-EF8/Program.cs
@@ -3,7 +3,7 @@ namespace AdventureWorks_EF8
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     internal class Program
     {
-        static void Main(string[] args)
+        static void Main()
         {
             Console.WriteLine("Hello, World!");
         }

--- a/extra-projects/AdventureWorks-EF9/Program.cs
+++ b/extra-projects/AdventureWorks-EF9/Program.cs
@@ -3,7 +3,7 @@ namespace AdventureWorks_EF9
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     internal class Program
     {
-        static void Main(string[] args)
+        static void Main()
         {
             Console.WriteLine("Hello, World!");
         }


### PR DESCRIPTION
## What this does

Two things:

1. **Fixes 4 real \`UnusedParameter.Local\` findings** in the AdventureWorks demo projects. \`Main(string[] args)\` → \`Main()\` in EF{7,8,9,10}/Program.cs — matches the EF6 sibling's already-argless \`Main()\`. Zero behavior change; \`args\` was never read.

2. **Triggers a fresh InspectCode analysis of \`main\`.** pr.yaml's \`inspectcode\` job runs only on \`pull_request_target\`, not on push-to-main. \`Microsoft.CodeAnalysis.PublicApiAnalyzers\` 3.3.4 → 5.6.0 landed via #385 but Code Scanning still shows 501 open alerts because no PR has run inspectcode against post-#385 main. This PR's run will refresh the SARIF.

## About the SeedCount finding

The 5th \"residual\" finding (\`UnusedAutoPropertyAccessor.Global\` on \`BuildAsyncBenchmarks.SeedCount\`) is **already fixed on main** — the \`// ReSharper disable once UnusedAutoPropertyAccessor.Global\` comment from PR-4 is present (verified via \`git show origin/main:benchmarks/…\`). That alert is stale SARIF and will close on the next inspectcode run.

## Expected effect after merge

| Rule | Before | After |
|---|--:|--:|
| RS0016 | 365 | 0 (analyzer 5.6.0 doesn't emit) |
| RS0037 | 91 | 0 |
| RS0036 | 40 | 0 |
| UnusedParameter.Local | 4 | 0 (fixed here) |
| UnusedAutoPropertyAccessor.Global | 1 | 0 (already fixed on main; stale SARIF) |
| **Total** | **501** | **~0** |

Comfortably clears the #377 target of <25.

## Release-scope note

0.8.1 is prepped on \`main\` (PR #384 merged) but not tagged yet. If you want these fixes IN 0.8.1, merge before tagging \`v0.8.1\`. Otherwise they land in 0.8.2. Either works — no API surface change.

## Fixed since previous push

Earlier push had merge conflicts because the branch was accidentally based on \`claude/mystifying-ramanujan-c1b4ce\` (from the closed PR #378 era), not on current \`main\`. That branch had an old \`.slnx.DotSettings\` layout so the diff included accidental changes to the settings file. Force-pushed a clean version based on current \`main\` — 4 files touched, ~4 lines each.

## References

- #377 (umbrella)
- #384 (0.8.1 release PR, merged)
- #385 (PublicApiAnalyzer bump, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)