### PR TITLE
chore(inspectcode): scope RS0016/RS0037 severity=none to tests + benchmarks (closes 433 alerts)

### DIFF
--- a/benchmarks/.editorconfig
+++ b/benchmarks/.editorconfig
@@ -45,3 +45,9 @@ dotnet_diagnostic.CA1051.severity = none
 # Stops cascading suppression-of-suppression noise when individual
 # benchmark files add narrowly-scoped pragmas.
 dotnet_diagnostic.IDE0079.severity = none
+
+# PublicApiAnalyzers RS0016/RS0036/RS0037 — see tests/.editorconfig for the
+# full rationale. Benchmarks have no PublicAPI.*.txt either.
+dotnet_diagnostic.RS0016.severity = none
+dotnet_diagnostic.RS0036.severity = none
+dotnet_diagnostic.RS0037.severity = none

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -46,3 +46,13 @@ dotnet_diagnostic.S1144.severity = none
 
 # xUnit2013: Use Assert.Single instead of Assert.Equal for collection size
 dotnet_diagnostic.xUnit2013.severity = none
+
+# PublicApiAnalyzers RS0016/RS0036/RS0037 — public API tracking is a src-only
+# concern. Test projects have no PublicAPI.*.txt (nor should they), so the
+# analyzer is dormant locally. But `jb inspectcode`'s Roslyn hosting still
+# emits these diagnostics on every public test class/method (~365 alerts
+# across the test suite). Silence at the tests scope only; src still gets
+# full RS0016 drift detection.
+dotnet_diagnostic.RS0016.severity = none
+dotnet_diagnostic.RS0036.severity = none
+dotnet_diagnostic.RS0037.severity = none


### PR DESCRIPTION
## What this closes

Latest InspectCode analysis of \`main\` (sha \`a58c96c\`) shows **497 open alerts**. Root-cause analysis:

| Rule | Location | Count | Category |
|---|---|--:|---|
| \`RS0016\` | tests | 328 | Test classes not in PublicAPI — **suppress-in-tests** |
| \`RS0016\` | benchmarks | 14 | Benchmark classes not in PublicAPI — **suppress-in-benchmarks** |
| \`RS0037\` | tests | 85 | \`PublicAPI.txt missing #nullable enable\` — tests have no PublicAPI.txt — **suppress-in-tests** |
| \`RS0037\` | benchmarks | 6 | Same for benchmarks — **suppress-in-benchmarks** |
| \`RS0016\` | src | 23 | **Real** missing PublicAPI entries — separate follow-up (see below) |
| \`RS0036\` | src | 40 | **Real** missing nullability annotations — separate follow-up |
| \`UnusedAutoPropertyAccessor.Global\` | benchmarks/BuildAsyncBenchmarks.cs | 1 | Already fixed on main; stale SARIF |

This PR handles the **433 legitimate suppressions** (328+14+85+6). Src is left untouched — those are real API-surface drift.

## Root-cause deep dive

- \`Microsoft.CodeAnalysis.PublicApiAnalyzers\` is PackageReferenced globally in \`Directory.Build.props\` (correct).
- It's designed to be dormant on projects without a \`PublicAPI.*.txt\` — verified: \`dotnet build tests/... -c Release\` fires **0** RS0016/37.
- But \`jb inspectcode\` triggers Roslyn analysis that surfaces these diagnostics at \`--severity=WARNING\` regardless of the analyzer's dormant state.
- The fix that would apply "globally" (silence solution-wide) is too broad — it would kill legitimate src-side drift detection.
- The right scope is **folder-level \`.editorconfig\` in tests/ and benchmarks/**, where PublicApiAnalyzer should never fire anyway.

## Not in this PR

**Src still has 63 real findings** (23 RS0016 + 40 RS0036):

- 0.7.0 added public API (\`UseSeedProfile\`, \`UseDiagnosticOutput\`, \`DbSetAssertions\`, \`Should\`, \`DbContextAssertionsExtensions\`, etc.) that was **never folded into \`PublicAPI.Shipped.txt\`**.
- PublicApiAnalyzer 5.6.0 lowered these diagnostics below \`warning\` severity by default, so \`TreatWarningsAsErrors=true\` doesn't catch them — but InspectCode's \`--severity=WARNING\` still emits them.
- Fix: separate PR that folds the missing entries into each src project's \`PublicAPI.Unshipped.txt\`. That's proper API-surface tracking, not suppression.

## Verified locally

- \`dotnet build src/Wolfgang.DbContextBuilder-Core/*.csproj -c Release -p:TreatWarningsAsErrors=true\` → 0 Errors
- \`dotnet build tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/*.csproj -c Release\` → 0 Errors
- \`dotnet build benchmarks/DbContextBuilder.Benchmarks/*.csproj -c Release\` → 0 Errors

## Expected effect

After this PR merges: **497 → ~64 alerts** (63 real src drift + 1 stale SeedCount).

## Release-scope note

0.8.1 is prepped on \`main\` (PR #384 merged) but not tagged. If you want this in 0.8.1, merge before tagging. Otherwise it lands in 0.8.2. Either works — the folder-level \`.editorconfig\` scoping is a build-noise fix, no functional change.

## References

- #377 (umbrella)
- #384 (0.8.1 release PR, merged)
- #385 (PublicApiAnalyzer bump, merged)
- #386 (Program.cs args cleanup, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)