### PR TITLE
build(analyzers): gate PublicApiAnalyzer PackageReference on Exists('PublicAPI.Shipped.txt') (protected-file bypass; closes ~433 InspectCode alerts)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -67,13 +67,17 @@
 
   <ItemGroup>
     <!-- A1: PublicApiAnalyzers — track public API surface for breaking-change
-         detection. AdditionalFiles below are opt-in PER PROJECT via Exists():
-         drop PublicAPI.Shipped.txt + PublicAPI.Unshipped.txt into a src
-         project directory and the analyzer activates for that project only.
-         Library projects under src/ should opt in; test / example /
-         benchmark projects should not. Per-repo enablement is tracked as a
-         follow-up maintenance issue. -->
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0">
+         detection. Opt-in PER PROJECT: drop PublicAPI.Shipped.txt +
+         PublicAPI.Unshipped.txt into a src project directory and the analyzer
+         both loads and activates for that project only. The Exists() gate on
+         the PackageReference below prevents the analyzer from being loaded on
+         projects that don't opt in (tests, benchmarks, examples, demo apps),
+         which under `jb inspectcode`'s hosting otherwise fire ~430 spurious
+         RS0016 / RS0037 diagnostics on every public test class/method.
+         Local `dotnet build` keeps the same PublicApiAnalyzer coverage for
+         src (opt-in) that it always had. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0"
+                      Condition="Exists('PublicAPI.Shipped.txt')">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

Replaces the closed #387 (which used \`.editorconfig\` \`severity = none\` — real suppression) with the architectural fix: don't LOAD \`PublicApiAnalyzer\` on projects that shouldn't be tracking public API.

**One-line change to \`Directory.Build.props\`**: add \`Condition=\"Exists('PublicAPI.Shipped.txt')\"\` to the \`PackageReference\`, mirroring the pattern the sibling \`AdditionalFiles\` block already uses.

## The design gap this fixes

\`Directory.Build.props\` had this intent-comment on the \`PublicApiAnalyzer\` \`PackageReference\`:

> Library projects under src/ should opt in; test / example / benchmark projects should not.

But the opt-in was only implemented for \`AdditionalFiles\` (via \`Exists('PublicAPI.Shipped.txt')\`). The \`PackageReference\` itself was unconditional. Under \`dotnet build\` that's fine — the analyzer stays dormant without a PublicAPI baseline. Under \`jb inspectcode\` it emits RS0016 / RS0037 for every public test class and method at \`--severity=WARNING\` regardless.

Result: **433 spurious InspectCode alerts** on tests + benchmarks:

| Rule | Location | Count |
|---|---|--:|
| \`RS0016\` | tests | 328 |
| \`RS0016\` | benchmarks | 14 |
| \`RS0037\` | tests | 85 |
| \`RS0037\` | benchmarks | 6 |
| **Total** | | **433** |

## Verified locally

\`project.assets.json\` reference counts for PublicApiAnalyzer after \`dotnet restore\`:

| Project | References before | References after |
|---|--:|--:|
| \`src/Wolfgang.DbContextBuilder-Core/\` | 25 | **25** (unchanged — analyzer still loaded) |
| \`tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/\` | 25 | **0** (analyzer not loaded) |

Builds:
- \`dotnet build src/Wolfgang.DbContextBuilder-Core/*.csproj -c Release -p:TreatWarningsAsErrors=true\` → **0 Errors** (src RS0016 enforcement intact)
- \`dotnet build tests/Wolfgang.DbContextBuilder-Core.Tests.Unit/*.csproj -c Release\` → **0 Errors**
- \`dotnet build benchmarks/DbContextBuilder.Benchmarks/*.csproj -c Release\` → **0 Errors**

## Why this is a bypass PR

\`Directory.Build.props\` is protected under pr.yaml's "Detect .NET Projects" guard. Same bypass flow as #385.

## Expected effect

Next InspectCode analysis of \`main\`: **497 → ~64** open alerts.

The remaining ~64 (23 RS0016 + 40 RS0036 on src, plus 1 stale SeedCount) are proper API-surface drift work — 0.7.0 additions (\`UseSeedProfile\`, \`UseDiagnosticOutput\`, \`DbSetAssertions.Should\`, etc.) never folded into \`PublicAPI.Shipped.txt\`. Real fix belongs in a separate PR that ADDS those entries to \`PublicAPI.Unshipped.txt\`, not suppression.

## References

- #377 (umbrella)
- #385 (established bypass pattern for DBP; PublicApiAnalyzers 3.3.4 → 5.6.0)
- #387 (closed — the suppression-first attempt this PR replaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)