### PR TITLE
release: finalize v0.8.1 — forwarded PublicAPI declaration + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,27 +19,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [0.8.1] - 2026-08-18
+## [0.8.1] - 2026-08-22
 
-Maintenance release — patch-safe dependency bumps and Code Scanning noise-floor
-cleanup. No public API changes; drop-in replacement for 0.8.0.
+Maintenance release — patch-safe dependency bumps, Code Scanning noise-floor
+cleanup, and PublicAPI baseline reconciliation. No source-code or public-API
+surface changes; drop-in replacement for 0.8.0.
 
 ### Changed
 
 - Bumped `SQLitePCLRaw.lib.e_sqlite3` `3.50.3` → `3.53.3` across all Core /
-  Core-EF6..10 src packages.
+  Core-EF6..10 src packages. (#384)
 - Bumped `Microsoft.NET.Test.Sdk` to `18.9.0` on every net8.0+ test/example path
   (net6.0/net7.0 branches keep `17.8.0`, which is the last Test.Sdk line that
   supports those target frameworks). (#384)
 - Bumped `System.Formats.Asn1` and `System.Text.Json` `10.0.9` → `10.0.11` in
-  the EF7 AdventureWorks demo project.
-- Bumped `Microsoft.CodeAnalysis.PublicApiAnalyzers` `3.3.4` → `5.6.0`
-  in `Directory.Build.props`. Aligns with the fleet-standard version
-  (matches ETL-Xml, which has 0 open InspectCode alerts on `main`) and
-  is expected to clear the residual ~496 spurious `RS0016` / `RS0037` /
-  `RS0036` findings on the Code Scanning dashboard — analyser 3.3.4
-  emitted those under InspectCode even with a valid `PublicAPI.*.txt`
-  file present, 5.6.0 does not.
+  the EF7 AdventureWorks demo project. (#384)
+- Bumped `Microsoft.CodeAnalysis.PublicApiAnalyzers` `3.3.4` → `5.6.0` in
+  `Directory.Build.props`. Aligns with the fleet-standard analyzer version
+  (matches ETL-Xml). (#385)
+- Gated the `PublicApiAnalyzers` `PackageReference` on
+  `Exists('PublicAPI.Shipped.txt')` so the analyzer is only loaded on src
+  projects that opt in — mirrors the pattern already used for the sibling
+  `AdditionalFiles` block and prevents ~433 spurious `RS0016` / `RS0037`
+  findings on tests and benchmarks under `jb inspectcode`'s Roslyn hosting.
+  (#388)
+- Folded 60 previously-shipped-but-un-declared public symbols across five
+  src projects (Core, EF6, Abstractions, AutoFixture, Bogus) into their
+  respective `PublicAPI.Shipped.txt` — 39 in-place annotation fixups
+  (`!` / `?` markers required by `#nullable enable`) plus 21 new
+  declarations promoted from Unshipped for 0.8.1. Zero source-code
+  changes; strictly a metadata reconciliation of what was already public
+  since 0.7.0 (`UseSeedProfile`, `UseDiagnosticOutput`,
+  `UseCustomRandomEntityCreator`, `DbSetAssertions.Should`,
+  `DbContextAssertionsExtensions.Should`, `UseSqlite<TDbContext>`,
+  `UseSqliteForMsSqlServer<TDbContext>`, and the whole
+  `DbSetAssertions<TEntity>` type surface). Also synced the five
+  `-Core-EF{6,7,8,9,10}` sibling packages' `Shipped.txt` to match `-Core`
+  (they compile the same source via `<Compile Include>` links, so their
+  assemblies expose an identical public surface), and declared the
+  type-forwarded `ICreateRandomEntities.CreateRandomEntities<TEntity>`
+  method that Core forwards from `.Abstractions` via
+  `[assembly: TypeForwardedTo]`. (#389, #390)
 
 ### Fixed
 

--- a/src/Wolfgang.DbContextBuilder-Core-EF10/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.DbContextBuilder-Core-EF10/PublicAPI.Shipped.txt
@@ -31,6 +31,7 @@ Wolfgang.DbContextBuilderCore.DbContextBuilderSqliteExtensions
 Wolfgang.DbContextBuilderCore.ICreateDbContext
 Wolfgang.DbContextBuilderCore.ICreateDbContext.CreateDbContextAsync<TDbContext>(Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<TDbContext!>! optionsBuilder) -> System.Threading.Tasks.Task<TDbContext!>!
 Wolfgang.DbContextBuilderCore.ICreateRandomEntities (forwarded, contained in Wolfgang.DbContextBuilder.Abstractions)
+Wolfgang.DbContextBuilderCore.ICreateRandomEntities.CreateRandomEntities<TEntity>(int count) -> System.Collections.Generic.IEnumerable<TEntity!>! (forwarded, contained in Wolfgang.DbContextBuilder.Abstractions)
 Wolfgang.DbContextBuilderCore.ISeedProfile<T>
 Wolfgang.DbContextBuilderCore.ISeedProfile<T>.Apply(Wolfgang.DbContextBuilderCore.DbContextBuilder<T!>! builder) -> void
 Wolfgang.DbContextBuilderCore.SqliteForMsSqlServerModelCustomizer

--- a/src/Wolfgang.DbContextBuilder-Core-EF6/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.DbContextBuilder-Core-EF6/PublicAPI.Shipped.txt
@@ -31,6 +31,7 @@ Wolfgang.DbContextBuilderCore.DbContextBuilderSqliteExtensions
 Wolfgang.DbContextBuilderCore.ICreateDbContext
 Wolfgang.DbContextBuilderCore.ICreateDbContext.CreateDbContextAsync<TDbContext>(Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<TDbContext!>! optionsBuilder) -> System.Threading.Tasks.Task<TDbContext!>!
 Wolfgang.DbContextBuilderCore.ICreateRandomEntities (forwarded, contained in Wolfgang.DbContextBuilder.Abstractions)
+Wolfgang.DbContextBuilderCore.ICreateRandomEntities.CreateRandomEntities<TEntity>(int count) -> System.Collections.Generic.IEnumerable<TEntity!>! (forwarded, contained in Wolfgang.DbContextBuilder.Abstractions)
 Wolfgang.DbContextBuilderCore.ISeedProfile<T>
 Wolfgang.DbContextBuilderCore.ISeedProfile<T>.Apply(Wolfgang.DbContextBuilderCore.DbContextBuilder<T!>! builder) -> void
 Wolfgang.DbContextBuilderCore.SqliteForMsSqlServerModelCustomizer

--- a/src/Wolfgang.DbContextBuilder-Core-EF7/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.DbContextBuilder-Core-EF7/PublicAPI.Shipped.txt
@@ -31,6 +31,7 @@ Wolfgang.DbContextBuilderCore.DbContextBuilderSqliteExtensions
 Wolfgang.DbContextBuilderCore.ICreateDbContext
 Wolfgang.DbContextBuilderCore.ICreateDbContext.CreateDbContextAsync<TDbContext>(Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<TDbContext!>! optionsBuilder) -> System.Threading.Tasks.Task<TDbContext!>!
 Wolfgang.DbContextBuilderCore.ICreateRandomEntities (forwarded, contained in Wolfgang.DbContextBuilder.Abstractions)
+Wolfgang.DbContextBuilderCore.ICreateRandomEntities.CreateRandomEntities<TEntity>(int count) -> System.Collections.Generic.IEnumerable<TEntity!>! (forwarded, contained in Wolfgang.DbContextBuilder.Abstractions)
 Wolfgang.DbContextBuilderCore.ISeedProfile<T>
 Wolfgang.DbContextBuilderCore.ISeedProfile<T>.Apply(Wolfgang.DbContextBuilderCore.DbContextBuilder<T!>! builder) -> void
 Wolfgang.DbContextBuilderCore.SqliteForMsSqlServerModelCustomizer

--- a/src/Wolfgang.DbContextBuilder-Core-EF8/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.DbContextBuilder-Core-EF8/PublicAPI.Shipped.txt
@@ -31,6 +31,7 @@ Wolfgang.DbContextBuilderCore.DbContextBuilderSqliteExtensions
 Wolfgang.DbContextBuilderCore.ICreateDbContext
 Wolfgang.DbContextBuilderCore.ICreateDbContext.CreateDbContextAsync<TDbContext>(Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<TDbContext!>! optionsBuilder) -> System.Threading.Tasks.Task<TDbContext!>!
 Wolfgang.DbContextBuilderCore.ICreateRandomEntities (forwarded, contained in Wolfgang.DbContextBuilder.Abstractions)
+Wolfgang.DbContextBuilderCore.ICreateRandomEntities.CreateRandomEntities<TEntity>(int count) -> System.Collections.Generic.IEnumerable<TEntity!>! (forwarded, contained in Wolfgang.DbContextBuilder.Abstractions)
 Wolfgang.DbContextBuilderCore.ISeedProfile<T>
 Wolfgang.DbContextBuilderCore.ISeedProfile<T>.Apply(Wolfgang.DbContextBuilderCore.DbContextBuilder<T!>! builder) -> void
 Wolfgang.DbContextBuilderCore.SqliteForMsSqlServerModelCustomizer

--- a/src/Wolfgang.DbContextBuilder-Core-EF9/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.DbContextBuilder-Core-EF9/PublicAPI.Shipped.txt
@@ -31,6 +31,7 @@ Wolfgang.DbContextBuilderCore.DbContextBuilderSqliteExtensions
 Wolfgang.DbContextBuilderCore.ICreateDbContext
 Wolfgang.DbContextBuilderCore.ICreateDbContext.CreateDbContextAsync<TDbContext>(Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<TDbContext!>! optionsBuilder) -> System.Threading.Tasks.Task<TDbContext!>!
 Wolfgang.DbContextBuilderCore.ICreateRandomEntities (forwarded, contained in Wolfgang.DbContextBuilder.Abstractions)
+Wolfgang.DbContextBuilderCore.ICreateRandomEntities.CreateRandomEntities<TEntity>(int count) -> System.Collections.Generic.IEnumerable<TEntity!>! (forwarded, contained in Wolfgang.DbContextBuilder.Abstractions)
 Wolfgang.DbContextBuilderCore.ISeedProfile<T>
 Wolfgang.DbContextBuilderCore.ISeedProfile<T>.Apply(Wolfgang.DbContextBuilderCore.DbContextBuilder<T!>! builder) -> void
 Wolfgang.DbContextBuilderCore.SqliteForMsSqlServerModelCustomizer

--- a/src/Wolfgang.DbContextBuilder-Core/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.DbContextBuilder-Core/PublicAPI.Shipped.txt
@@ -31,6 +31,7 @@ Wolfgang.DbContextBuilderCore.DbContextBuilderSqliteExtensions
 Wolfgang.DbContextBuilderCore.ICreateDbContext
 Wolfgang.DbContextBuilderCore.ICreateDbContext.CreateDbContextAsync<TDbContext>(Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<TDbContext!>! optionsBuilder) -> System.Threading.Tasks.Task<TDbContext!>!
 Wolfgang.DbContextBuilderCore.ICreateRandomEntities (forwarded, contained in Wolfgang.DbContextBuilder.Abstractions)
+Wolfgang.DbContextBuilderCore.ICreateRandomEntities.CreateRandomEntities<TEntity>(int count) -> System.Collections.Generic.IEnumerable<TEntity!>! (forwarded, contained in Wolfgang.DbContextBuilder.Abstractions)
 Wolfgang.DbContextBuilderCore.ISeedProfile<T>
 Wolfgang.DbContextBuilderCore.ISeedProfile<T>.Apply(Wolfgang.DbContextBuilderCore.DbContextBuilder<T!>! builder) -> void
 Wolfgang.DbContextBuilderCore.SqliteForMsSqlServerModelCustomizer


### PR DESCRIPTION
## Summary

**Final PR of the 0.8.1 release cut.** Merges the two remaining pieces of the release:

1. Declares the type-forwarded \`ICreateRandomEntities.CreateRandomEntities<TEntity>\` method entry that Core exposes via \`[assembly: TypeForwardedTo]\` from Abstractions — closes the last real \`RS0016\` alert on \`main\`.
2. Finalizes the \`## [0.8.1]\` CHANGELOG entry: sets the date to today (2026-08-22), rewrites the summary to acknowledge the PublicAPI metadata reconciliation, and attributes every bullet to the PRs that shipped it.

## What's in 0.8.1 (recap of the full cycle)

| PR | Scope |
|---|---|
| #379 | Rename \`.sln.DotSettings\` → \`.slnx.DotSettings\` + solution-wide DO_NOT_SHOW for RS0016/36/37 (tool-wide FP baseline) |
| #380 | Per-project \`.csproj.DotSettings\` for AdventureWorks EF-scaffolded generated code |
| #381 | Per-file \`#pragma warning disable EF1001\` for the 3 files that intentionally wrap EF internals |
| #382 | Triage of residual 41 alerts — real code fixes + narrow suppressions |
| #384 | Patch-safe NuGet bumps (SQLitePCLRaw, Test.Sdk, System.Formats.Asn1, System.Text.Json) + \`<Version>\` 0.8.0 → 0.8.1 + initial CHANGELOG |
| #385 | \`Microsoft.CodeAnalysis.PublicApiAnalyzers\` 3.3.4 → 5.6.0 (protected-file bypass) |
| #386 | Drop unused \`args\` from AdventureWorks demo Program.cs + trigger SARIF refresh |
| #388 | Gate \`PublicApiAnalyzers\` PackageReference on \`Exists('PublicAPI.Shipped.txt')\` — architectural fix, not suppression |
| #389 | Fold 60 missing/un-annotated PublicAPI symbols; sync -Core-EFx siblings; Unshipped → Shipped for 0.8.1 |
| **#390 (this PR)** | Forwarded \`ICreateRandomEntities.CreateRandomEntities\` declaration + finalize CHANGELOG |

## SemVer classification: **PATCH** (0.8.0 → 0.8.1)

Per \`feedback_patch_release_scope\`:
- **Zero source-code changes** to any public/protected member signature.
- **Zero new public API surface** — the PublicAPI additions in #389 are catching up on 0.7.0-era symbols that were already publicly usable but never declared in \`PublicAPI.*.txt\`. Metadata reconciliation, not new surface.
- \`dotnet pack -c Release\` against the 0.8.0 baseline succeeds without ApiCompat suppressions (verified locally on this branch).

## Verified locally

- \`dotnet build src/Wolfgang.DbContextBuilder-Core/*.csproj -c Release -p:TreatWarningsAsErrors=true\` → **0 Errors**
- \`dotnet pack src/Wolfgang.DbContextBuilder-Core/*.csproj -c Release\` → **Wolfgang.DbContextBuilder-Core.0.8.1.nupkg** created; PackageValidation vs 0.8.0 baseline passes.

## Test plan

- [ ] \`Detect .NET Projects\` guard passes (this PR touches only \`src/**/PublicAPI.Shipped.txt\` + \`CHANGELOG.md\`)
- [ ] Stage 1/2/3, InspectCode, all security scans green
- [ ] After merge, tag \`v0.8.1\` on main HEAD to trigger \`release.yaml\` (user tags per \`feedback_no_create_releases\`)

## Post-release (opened separately after tag)

- [ ] NuGet flatcontainer indexing for all 10 packages
- [ ] \`PackageValidationBaselineVersion\` 0.8.0 → 0.8.1 across all src csprojs (once CDN has 0.8.1)
- [ ] Delete \`vNext\` locally + branch cleanup
- [ ] Close umbrella #377 (InspectCode alerts driven from 2,999 to <5)

## References

- #377 (umbrella — InspectCode noise-floor cleanup)
- Full CHANGELOG entry: [\`CHANGELOG.md\` → \`## [0.8.1]\`](../blob/chore/publicapi-add-forwarded-createrandomentities/CHANGELOG.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)